### PR TITLE
FbTk/StringUtil.cc: Fix out-of-range memory access.

### DIFF
--- a/src/FbTk/StringUtil.cc
+++ b/src/FbTk/StringUtil.cc
@@ -176,7 +176,7 @@ string expandFilename(const string &filename) {
     size_t pos = filename.find_first_not_of(" \t");
     if (pos != string::npos && filename[pos] == '~') {
         retval = getenv("HOME");
-        if (pos != filename.size()) {
+        if (pos + 1 < filename.size()) {
             // copy from the character after '~'
             retval += static_cast<const char *>(filename.c_str() + pos + 1);
         }


### PR DESCRIPTION
if pos is not npos, it will always be less than filename.size().
However, the access later is only safe if there is a character
after pos, which would require pos + 1 to be less than filename.size.

This means that calling expandFilename with just ~ may produce an out of range memory access without this patch.
