### PR TITLE
Add workspaceBackAndForth option

### DIFF
--- a/doc/asciidoc/fluxbox-keys.txt
+++ b/doc/asciidoc/fluxbox-keys.txt
@@ -361,7 +361,10 @@ called).
 	going past the last workspace, whereas {Right,Left}Workspace do not.
 
 *Workspace* 'number'::
-	Jumps to the given workspace 'number'. The first workspace is *1*.
+	Jumps to the given workspace 'number', or to the previous workspace if
+	the target workspace is the current workspace and
+	*WorkspaceBackAndForth* is set. The first workspace is *1*.
+
 
 *NextWindow* [{'options'}] ['pattern'] / *PrevWindow* [{'options'}] ['pattern']::
 Focuses the next / previous window in the focus list.

--- a/doc/asciidoc/fluxbox.txt
+++ b/doc/asciidoc/fluxbox.txt
@@ -410,6 +410,10 @@ titlebars, not window contents.
     If enabled, you can drag windows from one workspace to another. The previous
 	 workspace is to the left, the next workspace is to the right.
 
+*Workspace Back And Forth*:::
+    If enabled, you can jump to a workspace back and forth with the same command
+    (or keyboard shortcut)
+
 Window Menu
 ~~~~~~~~~~~
 The Window menu is displayed when you right click on the titlebar of a window.

--- a/nls/C/Translation.m
+++ b/nls/C/Translation.m
@@ -82,6 +82,7 @@ $set 4 #Configmenu
 27 Ignore Resize Increment
 28 Disable Moving
 29 Disable Resizing
+32 Workspace Back And Forth
 
 $set 5 #Ewmh_OBSOLETE
 

--- a/nls/de_AT/Translation.m
+++ b/nls/de_AT/Translation.m
@@ -78,6 +78,7 @@ $set 4 #Configmenu
 27 Resize-Increment nicht beachten
 28 Position fixieren
 29 Größe fixieren
+32 Desktop hin- und herwechseln
 
 $set 5 #Ewmh
 

--- a/nls/de_CH/Translation.m
+++ b/nls/de_CH/Translation.m
@@ -78,6 +78,7 @@ $set 4 #Configmenu
 27 Resize-Increment nicht beachten
 28 Position fixieren
 29 Größe fixieren
+32 Desktop hin- und herwechseln
 
 $set 5 #Ewmh
 

--- a/nls/de_DE/Translation.m
+++ b/nls/de_DE/Translation.m
@@ -80,6 +80,7 @@ $set 4 #Configmenu
 29 Größe fixieren
 30 Fokus folgt Maus (strikt)
 31 Gleicher Head
+32 Desktop hin- und herwechseln
 
 $set 5 #Ewmh
 

--- a/nls/en_GB/Translation.m
+++ b/nls/en_GB/Translation.m
@@ -81,6 +81,7 @@ $set 4 #Configmenu
 27 Ignore Resize Increment
 28 Disable Moving
 29 Disable Resizing
+32 Workspace Back And Forth
 
 $set 5 #Ewmh
 

--- a/nls/en_US/Translation.m
+++ b/nls/en_US/Translation.m
@@ -81,6 +81,7 @@ $set 4 #Configmenu
 27 Ignore Resize Increment
 28 Disable Moving
 29 Disable Resizing
+32 Workspace Back And Forth
 
 $set 5 #Ewmh
 

--- a/nls/fluxbox-nls.hh
+++ b/nls/fluxbox-nls.hh
@@ -86,6 +86,7 @@ enum {
         ConfigmenuMaxDisableResize = 29,
 	ConfigmenuStrictMouseFocus = 30,
 	ConfigmenuFocusSameHead = 31,
+	ConfigmenuWorkspaceBackAndForth = 32,
 
 	EwmhSet = 5,
 	EwmhOutOfMemoryClientList = 1,

--- a/nls/fr_CH/Translation.m
+++ b/nls/fr_CH/Translation.m
@@ -69,6 +69,7 @@ $set 4 #Configmenu
 23 Largeur de l'onglet externe
 24 Sélectionner l'onglet par clique
 25 Sélectionner l'onglet avec la souris
+32 Va-et-vient entre bureaux
 
 $set 5 #Ewmh
 

--- a/nls/fr_FR/Translation.m
+++ b/nls/fr_FR/Translation.m
@@ -69,6 +69,7 @@ $set 4 #Configmenu
 23 Largeur de l'onglet externe
 24 Sélectionner l'onglet par clique
 25 Sélectionner l'onglet avec la souris
+32 Va-et-vient entre bureaux
 
 $set 5 #Ewmh
 

--- a/src/Screen.cc
+++ b/src/Screen.cc
@@ -1106,9 +1106,10 @@ void BScreen::changeWorkspaceID(unsigned int id, bool revert) {
 
     // set new workspace
     Workspace *old = currentWorkspace();
-    if (sameWs)
+    if (sameWs) {
       m_current_workspace = previousWorkspace();
-    else {
+      m_previous_workspace = old;
+    } else {
       m_previous_workspace = old;
       m_current_workspace = getWorkspace(id);
     }

--- a/src/Screen.hh
+++ b/src/Screen.hh
@@ -100,6 +100,7 @@ public:
     bool isRootColormapInstalled() const { return root_colormap_installed; }
     bool isScreenManaged() const { return managed; }
     bool isWorkspaceWarping() const { return (m_workspaces_list.size() > 1) && *resource.workspace_warping; }
+    bool isWorkspaceBackAndForth() const { return *resource.workspace_back_and_forth; }
     bool doAutoRaise() const { return *resource.auto_raise; }
     bool clickRaises() const { return *resource.click_raises; }
     bool doOpaqueMove() const { return *resource.opaque_move; }
@@ -150,6 +151,9 @@ public:
     /// @return the current workspace
     Workspace *currentWorkspace() { return m_current_workspace; }
     const Workspace *currentWorkspace() const { return m_current_workspace; }
+    /// @return the previous workspace
+    Workspace *previousWorkspace() { return m_previous_workspace; }
+    const Workspace *previousWorkspace() const { return m_previous_workspace; }
     /// @return the workspace menu
     const FbMenu &workspaceMenu() const { return *m_workspacemenu.get(); }
     /// @return the workspace menu
@@ -510,6 +514,7 @@ private:
     std::auto_ptr<Toolbar> m_toolbar;
 
     Workspace *m_current_workspace;
+    Workspace *m_previous_workspace;
 
     WorkspaceNames m_workspace_names;
     Workspaces m_workspaces_list;
@@ -532,7 +537,8 @@ private:
 
         FbTk::Resource<bool> opaque_move, full_max,
             max_ignore_inc, max_disable_move, max_disable_resize,
-            workspace_warping, show_window_pos, auto_raise, click_raises;
+            workspace_warping, workspace_back_and_forth, show_window_pos,
+            auto_raise, click_raises;
         FbTk::Resource<std::string> default_deco;
         FbTk::Resource<FbWinFrame::TabPlacement> tab_placement;
         FbTk::Resource<std::string> windowmenufile;


### PR DESCRIPTION
This is inspired by the i3wm 'workspace_auto_back_and_forth' feature. It allows
to jump back to the previous workspace (in time), when switching to the
workspace that is currently focused.

I didn't dare to commit the new man pages (fluxbox.1, fluxbox-keys.5).
