### PR TITLE
Fix menu rendering on style switch

### DIFF
--- a/src/FbTk/Menu.cc
+++ b/src/FbTk/Menu.cc
@@ -430,6 +430,8 @@ void Menu::updateMenu() {
         m_item_w = std::max(iw, m_item_w);
     }
 
+    // the menu width should be as wide as the widest menu item
+    w = m_item_w;
 
     // calculate needed columns
     m_columns = 0;


### PR DESCRIPTION
Different styles makes the menu width different.
When the original menu width is bigger than the newly selected style's
width, the rendering produces pretty strange effects:
The old style's frame not cleared, so it was rendered and visible next
to the new style edge.

With this change, the menu item width will be updated, so the old
style won't be visible.

Style switching still not perfect, because the height of a menu item is
from the "first" selected menu, also font color are not updated.