### PR TITLE
Placement layers fix

### DIFF
--- a/src/ColSmartPlacement.cc
+++ b/src/ColSmartPlacement.cc
@@ -99,6 +99,8 @@ bool ColSmartPlacement::placeWindow(const FluxboxWindow &win, int head,
             std::list<FluxboxWindow *>::const_iterator it_end = windowlist.end();
             for (; it != it_end && placed; ++it) {
                 if (*it == &win) continue;
+                if ((*it)->layerNum() != win.layerNum() ){ continue; } //windows are in different layers - skip it
+                
                 int bw = 2 * (*it)->fbWindow().borderWidth();
                 int curr_x = (*it)->x() - (*it)->xOffset();
                 int curr_y = (*it)->y() - (*it)->yOffset();

--- a/src/MinOverlapPlacement.cc
+++ b/src/MinOverlapPlacement.cc
@@ -144,7 +144,8 @@ bool MinOverlapPlacement::placeWindow(const FluxboxWindow &win, int head,
                                                    it_end = const_windowlist.rend();
     for (; it != it_end; ++it) {
         if (*it == &win) continue;
-
+        if ((*it)->layerNum() != win.layerNum() ){ continue; } //windows are in different layers - skip it
+        
         getWindowDimensions(*(*it), left, top, right, bottom);
 
         // go through the list of regions

--- a/src/RowSmartPlacement.cc
+++ b/src/RowSmartPlacement.cc
@@ -115,6 +115,7 @@ bool RowSmartPlacement::placeWindow(const FluxboxWindow &win, int head,
             for (; win_it != win_it_end && placed; ++win_it) {
                 FluxboxWindow &window = **win_it;
                 if (&window == &win) continue;
+                if (window.layerNum() != win.layerNum() ){ continue; } //windows are in different layers - skip it
 
                 int curr_x = window.x() - window.xOffset(); // minus offset to get back up to fake place
                 int curr_y = window.y() - window.yOffset();


### PR DESCRIPTION
This just makes the 3 "smart" placement algorithms only take windows within the same layer into consideration for placement purposes (so that a desktop-layer window is ignored when a new normal-layer window is being placed for example).

This only adds the fix for the RowSmartPlacement, ColSmartPlacement, and MinOverlapPlacement algorithms. If necessary this same one-liner can be added to any other algorithms as well.