### PR TITLE
Don't evaluate trusted variable in *ExportCmd::parse as it will be fa…

### DIFF
--- a/src/FbCommands.cc
+++ b/src/FbCommands.cc
@@ -170,7 +170,7 @@ FbTk::Command<void> *ExportCmd::parse(const string &command, const string &args,
     if (command != "setresourcevalue")
         FbTk::StringUtil::removeTrailingWhitespace(name);
     size_t pos = name.find_first_of(command == "export" ? "=" : " \t");
-    if (pos == string::npos || pos == name.size() || !trusted)
+    if (pos == string::npos || pos == name.size())
         return 0;
 
     string value = name.substr(pos + 1);


### PR DESCRIPTION
…lse alway for SetEnv, Export and SetResourceValue and never execute them via fluxbox-remote.

It is required to allow resource variable changes, for example:

$> fluxbox-remote 'SetResourceValue session.screen0.toolbar.placement BottomLeft'
$> fluxbox-remote 'Reconfig'

Without the fix the first command will do nothing as it always will return 0.
