### PR TITLE
Mixed relative and absolute values for apps

### DIFF
--- a/src/CurrentWindowCmd.cc
+++ b/src/CurrentWindowCmd.cc
@@ -500,27 +500,6 @@ void MoveCmd::real_execute() {
     fbwindow().move(fbwindow().x() + m_step_size_x, fbwindow().y() + m_step_size_y);
 }
 
-namespace {
-  template <typename Container>
-  static void parseToken(Container &container, int &d, bool &is_relative, bool &ignore) {
-      if (container.size() < 1)
-          return;
-
-      d = 0;
-      is_relative = false;
-      ignore = false;
-      if (container[0] == '*') {
-          ignore = true;
-      } else if (container[container.size() - 1] == '%') {
-          // its a percent
-          is_relative = true;
-          d = atoi(container.substr(0, container.size() - 1).c_str());
-      } else {
-          d = atoi(container.c_str());
-      }
-  }
-}
-
 FbTk::Command<void> *ResizeCmd::parse(const string &command, const string &args,
                                 bool trusted) {
 
@@ -536,15 +515,15 @@ FbTk::Command<void> *ResizeCmd::parse(const string &command, const string &args,
     bool is_relative_x = false, is_relative_y = false, ignore_x = false, ignore_y = false;
 
     if (command == "resizehorizontal") {
-        parseToken(tokens[0], dx, is_relative_x, ignore_x);
+        dx = FbTk::StringUtil::parseSizeToken(tokens[0], is_relative_x, ignore_x);
     } else if (command == "resizevertical") {
-        parseToken(tokens[0], dy, is_relative_y, ignore_y);
+        dy = FbTk::StringUtil::parseSizeToken(tokens[0], is_relative_y, ignore_y);
     } else {
         if (tokens.size() < 2) {
             return 0;
         }
-        parseToken(tokens[0], dx, is_relative_x, ignore_x);
-        parseToken(tokens[1], dy, is_relative_y, ignore_y);
+        dx = FbTk::StringUtil::parseSizeToken(tokens[0], is_relative_x, ignore_x);
+        dy = FbTk::StringUtil::parseSizeToken(tokens[1], is_relative_y, ignore_y);
     }
 
     if (command == "resizeto") {
@@ -610,8 +589,8 @@ FbTk::Command<void> *MoveToCmd::parse(const string &cmd, const string &args,
     int x = 0, y = 0;
     bool ignore_x = false, ignore_y = false, is_relative_x = false, is_relative_y = false;
 
-    parseToken(tokens[0], x, is_relative_x, ignore_x);
-    parseToken(tokens[1], y, is_relative_y, ignore_y);
+    x = FbTk::StringUtil::parseSizeToken(tokens[0], is_relative_x, ignore_x);
+    y = FbTk::StringUtil::parseSizeToken(tokens[1], is_relative_y, ignore_y);
 
     if (tokens.size() >= 3) {
         refc = FluxboxWindow::getCorner(tokens[2]);

--- a/src/FbTk/StringUtil.hh
+++ b/src/FbTk/StringUtil.hh
@@ -24,6 +24,12 @@
 
 #include <string>
 
+#ifdef HAVE_CSTDLIB
+#include <cstdlib>
+#else
+#include <stdlib.h>
+#endif
+
 namespace FbTk {
 
 namespace StringUtil {
@@ -61,12 +67,12 @@ std::string findExtension(const std::string &filename);
 /// @param found - position of found char in alphabet (optional)
 /// @return position of trigger if found
 /// @return std::string::npos if nothing found
-std::string::size_type findCharFromAlphabetAfterTrigger(const std::string& in, 
+std::string::size_type findCharFromAlphabetAfterTrigger(const std::string& in,
     char trigger,
     const char alphabet[], size_t len_alphabet, size_t* found);
 
 /// @return copy of original with find_string replaced with "replace"
-std::string replaceString(const std::string &original, 
+std::string replaceString(const std::string &original,
                           const char *find_string,
                           const char *replace);
 
@@ -141,6 +147,31 @@ stringtok (Container &container, std::string const &in,
         // set up for next loop
         i = j + 1;
     }
+}
+
+/// Parse token, which might be in formats as follows: <int>, <int>% or *.
+/// @param relative - parsed relative value (percentage suffix)
+/// @param ignore - this token should be ignored (asterisk)
+/// @return parsed integer value or 0 if not applicable
+template <typename Container>
+static int
+parseSizeToken(Container &container, bool &relative, bool &ignore) {
+
+    if (container.empty())
+        return 0;
+
+    relative = false;
+    ignore = false;
+
+    if (container[0] == '*') {
+        ignore = true;
+        return 0;
+    }
+
+    if (container[container.size() - 1] == '%')
+        relative = true;
+
+    return atoi(container.c_str());
 }
 
 } // end namespace StringUtil


### PR DESCRIPTION
Allow setting relative value for x and y or width and height separately in
the apps configuration file. This makes these settings compatible with ones
available in the keys file.

From now on it is possible to write something like this:
[app]
  [Position] (RIGHT) {50% 0}
  [Dimensions] {300 100%}
[end]

Note:
  Feature supported by this commit is not backward compatible.
  IMHO, the previous behavior was a bug, not a feature.

Signed-off-by: Arkadiusz Bokowy <arkadiusz.bokowy@gmail.com>