### PR TITLE
Make rubberband rectangles thicker for better visibility

### DIFF
--- a/src/RootTheme.cc
+++ b/src/RootTheme.cc
@@ -158,6 +158,10 @@ RootTheme::RootTheme(FbTk::ImageControl &image_control):
     m_opgc.setForeground(WhitePixel(disp, screenNum())^BlackPixel(disp, screenNum()));
     m_opgc.setFunction(GXxor);
     m_opgc.setSubwindowMode(IncludeInferiors);
+    m_opgc.setLineAttributes(3,
+			     FbTk::GContext::LINESOLID,
+			     FbTk::GContext::CAPBUTT,
+			     FbTk::GContext::JOINMITER);
     FbTk::ThemeManager::instance().loadTheme(*this);
 }
 


### PR DESCRIPTION
Current move/resize outline rectangles are one pixel wide, which can make them rather hard to see; especially on high-resolution monitors. This change makes the rectangles thicker (3 pixels), with the same square appearance (i.e. SolidLine, CapButt, JoinMiter).
