### PR TITLE
fix manpage fluxbox-keys

### DIFF
--- a/doc/asciidoc/fluxbox-style.txt
+++ b/doc/asciidoc/fluxbox-style.txt
@@ -248,7 +248,6 @@ options. Have fun.
    window.close.pixmap:            <filename>
    window.close.pressed.pixmap:    <filename>
    window.close.unfocus.pixmap:    <filename>
-   window.font:                    <font>
    window.frame.focusColor:        <color>
    window.frame.unfocusColor:      <color>
    window.grip.focus:              <texture type>
@@ -277,10 +276,12 @@ options. Have fun.
    window.label.focus:             <texture type>
    window.label.focus.color:       <color>
    window.label.focus.colorTo:     <color>
+   window.label.focus.font:        <font>
    window.label.focus.pixmap:      <filename>
    window.label.unfocus:           <texture type>
    window.label.unfocus.color:     <color>
    window.label.unfocus.colorTo:   <color>
+   window.label.unfocus.font:      <font>
    window.label.unfocus.pixmap:    <filename>
    window.label.focus.textColor:   <color>
    window.label.unfocus.textColor: <color>

--- a/doc/fluxbox-style.5.in
+++ b/doc/fluxbox-style.5.in
@@ -268,7 +268,6 @@ window\&.button\&.unfocus\&.pixmap:   <filename>
 window\&.close\&.pixmap:            <filename>
 window\&.close\&.pressed\&.pixmap:    <filename>
 window\&.close\&.unfocus\&.pixmap:    <filename>
-window\&.font:                    <font>
 window\&.frame\&.focusColor:        <color>
 window\&.frame\&.unfocusColor:      <color>
 window\&.grip\&.focus:              <texture type>
@@ -297,10 +296,12 @@ window\&.label\&.active\&.textColor:  <color>
 window\&.label\&.focus:             <texture type>
 window\&.label\&.focus\&.color:       <color>
 window\&.label\&.focus\&.colorTo:     <color>
+window\&.label\&.focus\&.font:        <font>
 window\&.label\&.focus\&.pixmap:      <filename>
 window\&.label\&.unfocus:           <texture type>
 window\&.label\&.unfocus\&.color:     <color>
 window\&.label\&.unfocus\&.colorTo:   <color>
+window\&.label\&.unfocus\&.font:      <font>
 window\&.label\&.unfocus\&.pixmap:    <filename>
 window\&.label\&.focus\&.textColor:   <color>
 window\&.label\&.unfocus\&.textColor: <color>


### PR DESCRIPTION
removed: window.font as it seems to have no effect
added:
  - window.label.focus.font
  - window.label.unfocus.font