### PR TITLE
textbox mods

### DIFF
--- a/src/FbTk/TextBox.cc
+++ b/src/FbTk/TextBox.cc
@@ -250,7 +250,7 @@ void TextBox::clear() {
 
 
     // draw cursor position
-    drawLine(gc(), cursor_pos, center_pos, cursor_pos, center_pos - font().height());
+    drawLine(gc(), cursor_pos, height()/2 + font().ascent()/2, cursor_pos, height()/2 - font().ascent()/2);
 }
 
 void TextBox::moveResize(int x, int y,

--- a/src/FbTk/TextBox.cc
+++ b/src/FbTk/TextBox.cc
@@ -211,7 +211,7 @@ void TextBox::clear() {
     Display *dpy = FbTk::App::instance()->display();
     FbWindow::clear();
     // center text by default
-    int center_pos = (height() + font().ascent())/2;
+    int center_pos = (height() - font().height())/2 + font().ascent();
     if (gc() == 0)
         setGC(DefaultGC(dpy, screenNumber()));
 

--- a/src/FbTk/TextBox.cc
+++ b/src/FbTk/TextBox.cc
@@ -58,7 +58,8 @@ TextBox::TextBox(int screen_num,
     m_start_pos(0),
     m_end_pos(0),
     m_select_pos(std::string::npos),
-    m_xic(0) {
+    m_padding(0),
+    m_xic(0){
 
     if (App::instance()->inputModule())
         m_xic = XCreateIC(App::instance()->inputModule(), XNInputStyle, XIMPreeditNothing | XIMStatusNothing, XNClientWindow, window(), NULL);
@@ -75,7 +76,8 @@ TextBox::TextBox(const FbWindow &parent,
     m_start_pos(0),
     m_end_pos(0),
     m_select_pos(std::string::npos),
-    m_xic(0) {
+    m_padding(0),
+    m_xic(0){
     if (App::instance()->inputModule())
         m_xic = XCreateIC(App::instance()->inputModule(), XNInputStyle, XIMPreeditNothing | XIMStatusNothing, XNClientWindow, window(), NULL);
     FbTk::EventManager::instance()->add(*this, *this);
@@ -96,6 +98,12 @@ void TextBox::setText(const FbTk::BiDiString &text) {
 
 void TextBox::setFont(const Font &font) {
     m_font = &font;
+}
+
+void TextBox::setPadding(int padding) {
+    m_padding = padding;
+    adjustPos();
+    clear();
 }
 
 void TextBox::setGC(GC gc) {
@@ -240,12 +248,24 @@ void TextBox::clear() {
     if (gc() == 0)
         setGC(DefaultGC(dpy, screenNumber()));
 
-
     int cursor_pos = font().textWidth(m_text.visual().c_str() + m_start_pos, m_cursor_pos);
+
+    int char_length = m_end_pos - m_start_pos;
+    int text_width = font().textWidth(m_text.visual().c_str() + m_start_pos, char_length);
+    int char_draw_length = char_length;
+    if (text_width > static_cast<signed>(width()) - 2*m_padding) {
+        // draw less text
+        int char_start_current = m_start_pos;
+        int char_end_current = m_end_pos;
+        adjustPos();
+        char_draw_length = m_end_pos - m_start_pos;
+        m_start_pos = char_start_current;
+        m_end_pos = char_end_current;
+    }
 
     font().drawText(*this, screenNumber(), gc(),
                     m_text.visual().c_str() + m_start_pos,
-                    m_end_pos - m_start_pos, -1, center_pos); // pos
+                    char_draw_length, m_padding, center_pos); // pos
 
     if (hasSelection()) {
         int select_pos = m_select_pos <= m_start_pos ? 0 :
@@ -253,14 +273,15 @@ void TextBox::clear() {
                                           m_select_pos - m_start_pos);
         int start = std::max(m_start_pos, std::min(m_start_pos + m_cursor_pos, m_select_pos));
         int length = std::max(m_start_pos + m_cursor_pos, m_select_pos) - start;
-        int x = std::min(select_pos, cursor_pos);
-        int width = std::abs(select_pos - cursor_pos);
+        length = std::min(length, char_draw_length);
+        int x = m_padding + std::min(select_pos, cursor_pos);
+        int select_width = std::min(std::abs(select_pos - cursor_pos), text_width);
 
         XGCValues backup;
         XGetGCValues(dpy, gc(), GCForeground|GCBackground, &backup);
         XSetForeground(dpy, gc(), backup.foreground);
 
-        fillRectangle(gc(), x, (height()-font().height())/2, width, font().height());
+        fillRectangle(gc(), x, (height()-font().height())/2, select_width, font().height());
 
         XColor c;
         c.pixel = backup.foreground;
@@ -275,7 +296,7 @@ void TextBox::clear() {
 
 
     // draw cursor position
-    drawLine(gc(), cursor_pos, height()/2 + font().ascent()/2, cursor_pos, height()/2 - font().ascent()/2);
+    drawLine(gc(), m_padding + cursor_pos, height()/2 + font().ascent()/2, m_padding + cursor_pos, height()/2 - font().ascent()/2);
 }
 
 void TextBox::moveResize(int x, int y,
@@ -302,7 +323,7 @@ void TextBox::buttonPressEvent(XButtonEvent &event) {
         int tmp = 0;
         for(i = m_start_pos; i <= m_end_pos; i++) {
             tmp = abs(static_cast<int>
-                      (event.x - font().textWidth(m_text.visual().c_str() + m_start_pos, i - m_start_pos)));
+                      (event.x - font().textWidth(m_text.visual().c_str() + m_start_pos, i - m_start_pos) - m_padding));
 
             if (tmp < delta) {
                 delta = tmp;
@@ -490,7 +511,7 @@ void TextBox::handleEvent(XEvent &event) {
 
 void TextBox::setCursorPosition(int pos) {
     m_cursor_pos = pos < 0 ? 0 : pos;
-    if (m_cursor_pos > text().size())
+    if (m_cursor_pos > text().size() - 2*m_padding)
         cursorEnd();
 }
 
@@ -498,7 +519,7 @@ void TextBox::adjustEndPos() {
     m_end_pos = text().size();
     m_start_pos = std::min(m_start_pos, m_end_pos);
     int text_width = font().textWidth(text().c_str() + m_start_pos, m_end_pos - m_start_pos);
-    while (text_width > static_cast<signed>(width())) {
+    while (text_width > (static_cast<signed>(width()) - 2*m_padding)) {
         m_end_pos--;
         text_width = font().textWidth(text().c_str() + m_start_pos, m_end_pos - m_start_pos);
     }
@@ -509,11 +530,11 @@ void TextBox::adjustStartPos() {
     const char* visual = m_text.visual().c_str();
 
     int text_width = font().textWidth(visual, m_end_pos);
-    if (m_cursor_pos >= 0 && text_width < static_cast<signed>(width()))
+    if (m_cursor_pos >= 0 && text_width < (static_cast<signed>(width()) - 2*m_padding))
         return;
 
     int start_pos = 0;
-    while (text_width > static_cast<signed>(width())) {
+    while (text_width > (static_cast<signed>(width()) - 2 * m_padding)) {
         start_pos++;
         text_width = font().textWidth(visual + start_pos, m_end_pos - start_pos);
     }

--- a/src/FbTk/TextBox.cc
+++ b/src/FbTk/TextBox.cc
@@ -285,6 +285,8 @@ void TextBox::buttonPressEvent(XButtonEvent &event) {
             }
         }
         m_cursor_pos = click_pos - m_start_pos;
+        m_select_pos = std::string::npos; // clear select
+        adjustPos();
         clear();
     }
 }

--- a/src/FbTk/TextBox.cc
+++ b/src/FbTk/TextBox.cc
@@ -123,6 +123,18 @@ void TextBox::cursorEnd() {
 void TextBox::cursorForward() {
     StringRange r = charRange(m_start_pos + cursorPosition());
     const std::string::size_type s = r.end - r.begin + 1;
+
+    if (hasSelection()) {
+        int start = std::max(m_start_pos, std::min(m_start_pos + m_cursor_pos, m_select_pos));
+        int select_length = std::max(m_start_pos + m_cursor_pos, m_select_pos) - start;
+        if (select_length > static_cast<signed>(m_end_pos - m_start_pos)) {
+            // shift range
+            m_start_pos += s;
+            m_end_pos += s;
+            adjustPos();
+        }
+    }
+
     if (r.end < m_end_pos)
         m_cursor_pos = r.end + 1 - m_start_pos;
     else if (m_end_pos < text().size()) {
@@ -133,9 +145,22 @@ void TextBox::cursorForward() {
 }
 
 void TextBox::cursorBackward() {
+
+    StringRange r = charRange(m_start_pos + cursorPosition() - 1);
+    const std::string::size_type s = r.end - r.begin + 1;
+
+    if (hasSelection()) {
+       int end = std::max(m_end_pos, std::min(m_end_pos - m_cursor_pos, m_select_pos));
+       int select_length = end - std::min(m_end_pos - m_cursor_pos, m_select_pos);
+       if (select_length > static_cast<signed>(m_end_pos - m_start_pos)) {
+           // shift range
+           m_start_pos -= s;
+           m_end_pos -= s;
+           adjustPos();
+       }
+    }
+
     if (m_start_pos || cursorPosition()) {
-        StringRange r = charRange(m_start_pos + cursorPosition() - 1);
-        const std::string::size_type s = r.end - r.begin + 1;
         if (cursorPosition())
             m_cursor_pos = r.begin - m_start_pos;
         else if (m_start_pos) {

--- a/src/FbTk/TextBox.cc
+++ b/src/FbTk/TextBox.cc
@@ -235,7 +235,7 @@ void TextBox::clear() {
         XGetGCValues(dpy, gc(), GCForeground|GCBackground, &backup);
         XSetForeground(dpy, gc(), backup.foreground);
 
-        fillRectangle(gc(), x, 0, width, height());
+        fillRectangle(gc(), x, (height()-font().height())/2, width, font().height());
 
         XColor c;
         c.pixel = backup.foreground;

--- a/src/FbTk/TextBox.hh
+++ b/src/FbTk/TextBox.hh
@@ -37,6 +37,7 @@ public:
     virtual ~TextBox();
 
     void setText(const FbTk::BiDiString &text);
+    void setPadding(int padding);
     void setFont(const Font &font);
     void setGC(GC gc);
     void setCursorPosition(int cursor);
@@ -87,6 +88,7 @@ private:
     BiDiString m_text;
     GC m_gc;
     std::string::size_type m_cursor_pos, m_start_pos, m_end_pos, m_select_pos;
+    int m_padding;
     XIC m_xic;
 };
 

--- a/util/fbrun/FbRun.cc
+++ b/util/fbrun/FbRun.cc
@@ -62,6 +62,7 @@ FbRun::FbRun(int x, int y, size_t width):
     m_font("fixed"),
     m_display(FbTk::App::instance()->display()),
     m_bevel(4),
+    m_padding(0),
     m_gc(*this),
     m_end(false),
     m_current_history_item(0),
@@ -250,6 +251,11 @@ void FbRun::setTitle(const string &title) {
 
 void FbRun::resize(unsigned int width, unsigned int height) {
     FbTk::TextBox::resize(width, height);
+}
+
+void FbRun::setPadding(int padding) {
+    m_padding = padding;
+    FbTk::TextBox::setPadding(padding);
 }
 
 void FbRun::redrawLabel() {

--- a/util/fbrun/FbRun.hh
+++ b/util/fbrun/FbRun.hh
@@ -43,6 +43,7 @@ public:
     void resize(unsigned int width, unsigned int height);
     void setPrint(bool print) { m_print = print; }
     void setAutocomplete(bool complete) { m_autocomplete = complete; }
+    void setPadding(int padding);
 
     /// load and reconfigure for new font
     bool loadFont(const std::string &fontname);
@@ -89,6 +90,7 @@ private:
     FbTk::Font m_font; ///< font used to draw command text
     Display *m_display;  ///< display connection
     int m_bevel;
+    int m_padding;
     FbTk::GContext m_gc; ///< graphic context
     bool m_end; ///< marks when this object is done
 

--- a/util/fbrun/main.cc
+++ b/util/fbrun/main.cc
@@ -58,6 +58,7 @@ void showUsage(const char *progname) {
         "   -print                      Print result to stdout"<<endl<<
         "   -w [width]                  Window width in pixels"<<endl<<
         "   -h [height]                 Window height in pixels"<<endl<<
+        "   -pad [size]                 Padding size in pixels"<<endl<<
         "   -display [display string]   Display name"<<endl<<
         "   -pos [x] [y]                Window position in pixels"<<endl<<
         "   -nearmouse                  Window position near mouse"<<endl<<
@@ -76,6 +77,7 @@ int main(int argc, char **argv) {
     int x = 0, y = 0; // default pos of window
     size_t width = 200, height = 32; // default size of window
     bool set_height = false, set_width=false; // use height/width of font by default
+    int padding = 0; // default horizontal padding for text
     bool set_pos = false; // set position
     bool near_mouse = false; // popup near mouse
     bool center = false;
@@ -107,6 +109,8 @@ int main(int argc, char **argv) {
         } else if (arg == "-h" && i+1 < argc) {
             height = atoi(argv[++i]);
             set_height = true; // mark true else the height of font will be used
+        } else if (arg == "-pad" && i+1 < argc) {
+            padding = atoi(argv[++i]);
         } else if ((arg == "-display" || arg == "--display") && i+1 < argc) {
             display_name = argv[++i];
         } else if ((arg == "-pos" || arg == "--pos") && i+2 < argc) {
@@ -180,8 +184,10 @@ int main(int argc, char **argv) {
                 cerr<<"FbRun Warning: Failed to load completion file: "<<expanded_filename<<endl;
         }
 
+        fbrun.setPadding(padding);
         fbrun.setTitle(title);
         fbrun.setText(text);
+
         if (preselect)
             fbrun.selectAll();
 


### PR DESCRIPTION
Admittedly my only target was making Fbrun look nice(r) here..

    ./fbrun [-pad 25] -pos 2805 517 -bg "#111" -fg white -font "liberation sans-42" -h 75 -w 175 -text "boxy mcflux box"

![2018mar10 textbox](https://user-images.githubusercontent.com/2130062/37247407-56beabe2-24b2-11e8-8031-77b107619f39.png)

1 (old) vs 2 (new): note the text vertical centering, the cursor position and size, and finally the padding
3 (old) vs 5 (new): note the minimal text selection height
4 (old) vs 6 (new): note the selection deselection behaviour - which still has a text selection? (answer - both have identical selections!) [test using 'home -> shift + end -> shift + left cursor x 9]

There are a few additional comments in the commits, otherwise, hoping this is sufficient detail.

Thanks for all your work on Fluxbox!