### PR TITLE
make: add src/defaults.* to cleanfiles

### DIFF
--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -23,7 +23,7 @@
 # DEALINGS IN THE SOFTWARE.
 
 BUILT_SOURCES = src/defaults.hh src/defaults.cc
-CONFIG_CLEAN_FILES = src/defaults.hh src/defaults.cc
+CLEANFILES += src/defaults.hh src/defaults.cc
 
 LDADD = libFbTk.a src/defaults.$(OBJEXT)
 


### PR DESCRIPTION
These two files weren't removed when running `make clean`.
After they have been created, once `make` was run, they would never change.
You'd have to remove them manually, e.g. if you wanted to provide a different
prefix with `./configure --prefix=alt`