### PR TITLE
Document fact that ALL menu items ARE allowed in window menu

### DIFF
--- a/doc/asciidoc/fluxbox-menu.txt
+++ b/doc/asciidoc/fluxbox-menu.txt
@@ -50,7 +50,7 @@ which appears when you right-click on a window's titlebar or iconbar. This opens
 a menu file as defined by *~/.fluxbox/windowmenu*. If this file does not exist,
 fluxbox will copy in the default from *@pkgdatadir@/windowmenu*.
 
-You do not need to ``reload'' fluxbox after editing the apps file, the changes
+You do not need to ``reload'' fluxbox after editing either menu file, the changes
 should be taken into account the next time you open the menu.
 
 ROOT MENU
@@ -188,11 +188,12 @@ Fluxbox Functions
 
 WINDOW MENU
 -----------
-Like the *ROOT MENU*, this menu file must start with *[begin]* and end with
-*[end]*. However, this file consists of only one *[*'tag'*]* per line with no
-labels, commands, or icons.
+The syntax for the Window Menu is mostly identical to that for the *ROOT MENU*;
+it must start with *[begin]* and end with *[end]*, and may have any of the above
+tags. However, it may also contain any of the following window-specific *[*'tag'*]*s,
+which each must be on a line by itself with no labels, commands, or icons.
 
-The available tags in this menu are:
+The additonal available tags in this menu are:
 
 *[shade]*;;
     Provides a menu item to shade or unshade (or, roll-up) the window. This is

--- a/doc/fluxbox-menu.5.in
+++ b/doc/fluxbox-menu.5.in
@@ -53,7 +53,7 @@ Fluxbox installs a default root menu file in \fB@pkgdatadir@/menu\fR\&. You can 
 .sp
 The second type is the \fBWINDOW MENU\fR, which defines the contents of the menu which appears when you right\-click on a window\(cqs titlebar or iconbar\&. This opens a menu file as defined by \fB~/\&.fluxbox/windowmenu\fR\&. If this file does not exist, fluxbox will copy in the default from \fB@pkgdatadir@/windowmenu\fR\&.
 .sp
-You do not need to \(lqreload\(rq fluxbox after editing the apps file, the changes should be taken into account the next time you open the menu\&.
+You do not need to \(lqreload\(rq fluxbox after editing either menu file, the changes should be taken into account the next time you open the menu\&.
 .SH "ROOT MENU"
 .sp
 The root menu must begin with a \fB[begin]\fR tag and end with an \fB[end]\fR tag, and every tag must be on its own line\&.
@@ -238,9 +238,9 @@ for more information\&.
 .RE
 .SH "WINDOW MENU"
 .sp
-Like the \fBROOT MENU\fR, this menu file must start with \fB[begin]\fR and end with \fB[end]\fR\&. However, this file consists of only one \fB[\fR\fItag\fR\fB]\fR per line with no labels, commands, or icons\&.
+The syntax for the Window Menu is mostly identical to that for the \fBROOT MENU\fR; it must start with \fB[begin]\fR and end with \fB[end]\fR, and may have any of the above tags\&. However, it may also contain any of the following window-specific \fB[\fR\fItag\fR\fB]\fRs, which each must be on a line by itself with no labels, commands, or icons\&.
 .sp
-The available tags in this menu are:
+The additional available tags in this menu are:
 .PP
 \fB[shade]\fR
 .RS 4


### PR DESCRIPTION
This is a documentation-only pull request, and as such I hope it can easily be accepted and merged. In particular, it would be great to get the update onto the Fluxbox website, because right now the documentation gives the impression that the window menu is quite limited, when in fact it is very powerful, and especially using the commands from the keys file, can include operations like resizing and repositioning the window, moving it to another workspace and following the window (as opposed to just sending it there while staying on the current workspace), etc. I think it might possibly help fluxbox retain some of its former popularity if it was clear how powerful the window menu really is. 