### PR TITLE
Fluxstyle

### DIFF
--- a/3rd/vim/Makefile
+++ b/3rd/vim/Makefile
@@ -1,7 +1,8 @@
 PLUGIN = fluxbox
 SOURCE = syntax/fluxapps.vim \
 		 syntax/fluxkeys.vim \
-		 syntax/fluxmenu.vim
+		 syntax/fluxmenu.vim \
+		 syntax/fluxstyle.vim
 
 ${PLUGIN}.vba: $(SOURCE) compile_vba.sh Makefile
 	sh ./compile_vba.sh $(SOURCE) > $@

--- a/3rd/vim/Makefile
+++ b/3rd/vim/Makefile
@@ -2,7 +2,8 @@ PLUGIN = fluxbox
 SOURCE = syntax/fluxapps.vim \
 		 syntax/fluxkeys.vim \
 		 syntax/fluxmenu.vim \
-		 syntax/fluxstyle.vim
+		 syntax/fluxstyle.vim \
+		 ftdetect/fluxbox.vim
 
 ${PLUGIN}.vba: $(SOURCE) compile_vba.sh Makefile
 	sh ./compile_vba.sh $(SOURCE) > $@

--- a/3rd/vim/ftdetect/fluxbox.vim
+++ b/3rd/vim/ftdetect/fluxbox.vim
@@ -3,4 +3,5 @@ if has("autocmd")
     autocmd BufNewFile,BufRead */.fluxbox/apps setf fluxapps
     autocmd BufNewFile,BufRead */.fluxbox/keys setf fluxkeys
     autocmd BufNewFile,BufRead */.fluxbox/menu setf fluxmenu
+    autocmd BufNewfile,BufRead */.fluxbox/styles/* setf fluxstyle
 endif

--- a/3rd/vim/syntax/fluxstyle.vim
+++ b/3rd/vim/syntax/fluxstyle.vim
@@ -1,0 +1,41 @@
+" File Name: fluxstyle.vim
+" Maintainer: Jason Carpenter <argonaut.linux@gmail.com>
+" Original Date: June 30, 2019
+" Last Update: June 30, 2019
+" Description: fluxbox style syntax file
+
+" Quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+" turn case on
+syn case match
+
+syn match   fbStyleLabel +^[^:]\{-}:+he=e-1   contains=fbStylePunct,fbStyleSpecial,fbStyleLineEnd
+
+syn region  fbStyleValue   keepend start=+:+lc=1 skip=+\\+ end=+$+ contains=fbStyleSpecial,fbStyleLabel,fbStyleLineEnd
+
+syn match   fbStyleSpecial    contained +#override+
+syn match   fbStyleSpecial    contained +#augment+
+syn match   fbStylePunct      contained +[.*:]+
+syn match   fbStyleLineEnd    contained +\\$+
+syn match   fbStyleLineEnd    contained +\\n\\$+
+syn match   fbStyleLineEnd    contained +\\n$+
+
+syn match   fbStyleComment "^!.*$"    contains=fbStyleTodo,@Spell
+syn region  fbStyleComment start="/\*" end="\*/"       contains=fsStyleTodo,@Spell
+
+syn keyword fbStyleTodo contained TODO FIXME XXX display
+
+highlight link fbStyleLabel     Type
+highlight link fbStyleValue   Constant
+highlight link fbStyleComment   Comment
+highlight link fbStyleSpecial   Statement
+highlight link fbStylePunct     Normal
+highlight link fbStyleLineEnd   Special
+highlight link fbStyleTodo      Todo
+
+syntax sync fromstart
+
+let b:current_syntax = 'fluxstyle'


### PR DESCRIPTION
Add syntax highlighting in vim for fluxbox styles.  Pretty basic.  Mostly copied from the syntax file for xdefaults.  Also add ftdetect script to the Vimball so that it is installed as well.