### PR TITLE
removed potential division by zero with size zero fonts

### DIFF
--- a/src/FbTk/XftFontImp.cc
+++ b/src/FbTk/XftFontImp.cc
@@ -78,8 +78,8 @@ bool XftFontImp::load(const std::string &name) {
     // overflow'). to prevent something like this we detect the maximium
     // number of glyphs by calculating the amount of 'WW' (pretending a 'wide'
     // glyph) fitting into 32k pixels 
-    unsigned int tw = textWidth("WW", 2);
-    m_maxlength = 0x8000 / (tw == 0 ? 1 : tw);
+    unsigned int tw = std::max(textWidth("WW", 2), 1);
+    m_maxlength = 0x8000 / tw;
 
     return true;
 }

--- a/src/FbTk/XftFontImp.cc
+++ b/src/FbTk/XftFontImp.cc
@@ -79,7 +79,7 @@ bool XftFontImp::load(const std::string &name) {
     // number of glyphs by calculating the amount of 'WW' (pretending a 'wide'
     // glyph) fitting into 32k pixels 
     unsigned int tw = textWidth("WW", 2);
-    m_maxlength = 0x8000 / tw;
+    m_maxlength = 0x8000 / (tw == 0 ? 1 : tw);
 
     return true;
 }


### PR DESCRIPTION
I found a bug where when a style tries to load a size zero font it'll cause fluxbox to crash with a floating point exception.

The offending line in the style was:
window.font: hermit-0

Changing the font size in the style fixes the issue but it's kind of a hard bug to diagnose for users so I propose putting a check into the source to prevent it from crashing the window manager in other styles.