### PR TITLE
Handle sizehint base_width / base_height being less than 0

### DIFF
--- a/src/WindowState.cc
+++ b/src/WindowState.cc
@@ -113,8 +113,9 @@ void SizeHints::reset(const XSizeHints &sizehint) {
         min_width = min_height = 1;
 
     if (sizehint.flags & PBaseSize) {
-        base_width = sizehint.base_width;
-        base_height = sizehint.base_height;
+        base_width = std::max(sizehint.base_width, 0);
+        base_height = std::max(sizehint.base_height, 0);
+
         if (!(sizehint.flags & PMinSize)) {
             min_width = base_width;
             min_height = base_height;


### PR DESCRIPTION
Some applications supply -1 in base_width / base_height. One example is
the Preferences dialog of pcmanfm-qt:

WM_NORMAL_HINTS(WM_SIZE_HINTS):
  ...
  program specified base size: -1 by -1

Without this commit the program will crash due to overflow of unsigned int.