### PR TITLE
Initial implementation of shortcut to windows

### DIFF
--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -233,6 +233,8 @@ fluxbox_SOURCES = \
 	src/ScreenResource.hh \
 	src/SendToMenu.cc \
 	src/SendToMenu.hh \
+	src/ShortcutManager.cc \
+	src/ShortcutManager.hh \
 	src/Strut.hh \
 	src/StyleMenuItem.cc \
 	src/StyleMenuItem.hh \

--- a/src/ShortcutManager.cc
+++ b/src/ShortcutManager.cc
@@ -17,7 +17,7 @@ unsigned int ShortcutManager::getLastPlaceHolderKey()
 
 void ShortcutManager::mapKeyToWindow(unsigned int key, FluxboxWindow* window)
 {
-    m_key_to_window_map.insert(std::make_pair(key, window));
+    m_key_to_window_map[key] = window;
 }
 
 void ShortcutManager::removeWindow(FluxboxWindow* window)

--- a/src/ShortcutManager.cc
+++ b/src/ShortcutManager.cc
@@ -1,0 +1,45 @@
+#include "ShortcutManager.hh"
+#include "Debug.hh"
+
+#include <iostream>
+
+ShortcutManager::ShortcutManager() : m_last_placeholder_key(0) { }
+
+void ShortcutManager::setLastPlaceHolderKey(unsigned int lastPlaceHolderKey_)
+{
+    m_last_placeholder_key = lastPlaceHolderKey_;
+}
+
+unsigned int ShortcutManager::getLastPlaceHolderKey()
+{
+    return m_last_placeholder_key;
+}
+
+void ShortcutManager::mapKeyToWindow(unsigned int key, FluxboxWindow* window)
+{
+    m_key_to_window_map.insert(std::make_pair(key, window));
+}
+
+void ShortcutManager::removeWindow(FluxboxWindow* window)
+{
+    KeyToWindowMap::const_iterator it;
+    for (it = m_key_to_window_map.begin(); it != m_key_to_window_map.end(); ++it) {
+        if (it->second == window){
+            fbdbg << "Remove mapping window[" << window
+                  << "] key [" << it->first << "]" << std::endl;
+            m_key_to_window_map.erase(it);
+            return;
+        }
+    }
+}
+
+FluxboxWindow* ShortcutManager::getWindowForKey(unsigned int key)
+{
+    KeyToWindowMap::const_iterator it = m_key_to_window_map.find(key);
+    if (it != m_key_to_window_map.end()) {
+        return it->second;
+    }
+    else {
+        return nullptr;
+    }
+}

--- a/src/ShortcutManager.hh
+++ b/src/ShortcutManager.hh
@@ -1,0 +1,32 @@
+#ifndef SHORTCUTMANAGER_HH
+#define SHORTCUTMANAGER_HH
+
+#include <map>
+
+class FluxboxWindow;
+
+class ShortcutManager {
+
+public:
+
+    ShortcutManager();
+
+    void setLastPlaceHolderKey(unsigned int lastPlaceHolderKey_);
+
+    unsigned int getLastPlaceHolderKey();
+
+    void mapKeyToWindow(unsigned int key, FluxboxWindow* window);
+
+    void removeWindow(FluxboxWindow* window);
+
+    FluxboxWindow* getWindowForKey(unsigned int key);
+
+private:
+
+    typedef std::map<unsigned int, FluxboxWindow*> KeyToWindowMap;
+
+    unsigned int m_last_placeholder_key;
+    KeyToWindowMap m_key_to_window_map;
+};
+
+#endif

--- a/src/Window.cc
+++ b/src/Window.cc
@@ -353,6 +353,7 @@ FluxboxWindow::~FluxboxWindow() {
     // no longer a valid window to do stuff with
     Fluxbox::instance()->removeWindowSearchGroup(frame().window().window());
     Fluxbox::instance()->removeWindowSearchGroup(frame().tabcontainer().window());
+    Fluxbox::instance()->shortcutManager().removeWindow(this);
 
     Client2ButtonMap::iterator it = m_labelbuttons.begin();
     Client2ButtonMap::iterator it_end = m_labelbuttons.end();

--- a/src/WorkspaceCmd.cc
+++ b/src/WorkspaceCmd.cc
@@ -39,6 +39,8 @@
 #include "FbTk/stringstream.hh"
 #include "FbTk/StringUtil.hh"
 
+#include "Debug.hh"
+
 #ifdef HAVE_CMATH
   #include <cmath>
 #else
@@ -751,3 +753,38 @@ FbTk::Command<void> *RelabelButtonCmd::parse(const std::string &command,
 
 REGISTER_COMMAND_PARSER(relabelbutton, RelabelButtonCmd::parse, void);
 
+void MarkWindowCmd::execute() {
+    BScreen *screen = Fluxbox::instance()->keyScreen();
+    if (screen) {
+
+        FluxboxWindow* window = screen->focusControl().focusedFbWindow();
+        if (window) {
+            ShortcutManager &shortcutManager = Fluxbox::instance()->shortcutManager();
+            unsigned int key = shortcutManager.getLastPlaceHolderKey();
+            shortcutManager.mapKeyToWindow(key, window);
+            fbdbg << "Map window[" << window << "] to key[" << key << "]" << std::endl;
+        }
+    }
+}
+
+REGISTER_COMMAND(markwindow, MarkWindowCmd, void);
+
+void GotoMarkedWindowCmd::execute() {
+
+    ShortcutManager &shortcutManager = Fluxbox::instance()->shortcutManager();
+    unsigned int key = shortcutManager.getLastPlaceHolderKey();
+
+    FluxboxWindow *window = shortcutManager.getWindowForKey(key);
+    if (window) {
+
+        if (window->isIconic()) {
+            window->deiconify(false);
+        }
+        window->raiseAndFocus();
+
+        fbdbg << "Raise and focus window[" << window
+              << "] mapped to key[" << key << "]" << std::endl;
+    }
+}
+
+REGISTER_COMMAND(gotomarkedwindow, GotoMarkedWindowCmd, void);

--- a/src/WorkspaceCmd.hh
+++ b/src/WorkspaceCmd.hh
@@ -236,4 +236,14 @@ private:
     std::string m_button, m_label;
 };
 
+class MarkWindowCmd: public FbTk::Command<void> {
+public:
+    void execute();
+};
+
+class GotoMarkedWindowCmd: public FbTk::Command<void> {
+public:
+    void execute();
+};
+
 #endif // WORKSPACECMD_HH

--- a/src/fluxbox.cc
+++ b/src/fluxbox.cc
@@ -272,7 +272,8 @@ Fluxbox::Fluxbox(int argc, char **argv,
       m_masked_window(0),
       m_argv(argv), m_argc(argc),
       m_showing_dialog(false),
-      m_server_grabs(0) {
+      m_server_grabs(0),
+      m_shortcut_manager(new ShortcutManager) {
 
     _FB_USES_NLS;
 

--- a/src/fluxbox.hh
+++ b/src/fluxbox.hh
@@ -32,6 +32,7 @@
 #include "FbTk/MenuSearch.hh"
 
 #include "AttentionNoticeHandler.hh"
+#include "ShortcutManager.hh"
 
 #include <X11/Xresource.h>
 
@@ -185,6 +186,7 @@ public:
     const XEvent &lastEvent() const { return m_last_event; }
 
     AttentionNoticeHandler &attentionHandler() { return m_attention_handler; }
+    ShortcutManager &shortcutManager() { return *m_shortcut_manager; }
 
 private:
     std::string getRcFilename();
@@ -306,6 +308,7 @@ private:
     } m_state;
 
     int m_server_grabs;
+    std::unique_ptr<ShortcutManager> m_shortcut_manager;
 };
 
 


### PR DESCRIPTION
Hello fluxbox developers:

I would like to submit this new feature I named "shortcut to windows". I've been using this feature personally for myself for some time and I've found it very useful. It allows a user to assign a shortcut to a window and jump directly to that window instead of pressing `alt-tab` multiple times. 

It is my first time submitting a pull request. If there are any standard templates I need to follow for the pull request write up, then please let me know and I will be happy to submit again.

Thank you
Richard

----

### PURPOSE

In editors such as vi and emacs, a user can mark a line in a file with a shortcut key and afterwards jump back to that line using the shortcut.

The idea is extended to opened windows. A user can assign a keyboard shortcut to an opened window.  Afterwards, the shortcut can be used to switch focus back to the marked window.

Such shortcuts save the user from pressing `alt+tab` multiple times to cycle through windows until the desired one is found.

### EXAMPLE USAGE

The following binding is added to file `~/.fluxbox/keys`:

    Mod1 m ARG :MarkWindow

    Mod1 g ARG :GotoMarkedWindow

User enters `alt+m x` to mark the currently focused window with shortcut key 'x'

User enters `alt+g x` to switch focus to the marked window

### IMPLEMENTATION SUMMARY

- Two new commands were added `:MarkWindow` and `:GotoMarkedWindow`
- Keys.cc was modified:
    - `addBinding()` method supports parsing an argument placeholder where the user can pass in a shortcut key
    - `doAction()` method forwards the shortcut key to the command to execute
    - Class `Keys::t_key` was modified to recognize a placeholder key
- New class `ShortcutManager` was added to maintain mapping of shortcut keys to marked windows
