### PR TITLE
Iconbar alignment

### DIFF
--- a/doc/fluxbox.1.in
+++ b/doc/fluxbox.1.in
@@ -1201,6 +1201,11 @@ All icons will be left\-aligned with the width set in the \(oqinit\(cq file
 All icons will be sized evenly to fill the iconbar completely
 .RE
 .PP
+\fBRelativeSmart\fR:
+.RS 4
+All icons will initially be sized evenly, but icons with long titles will be larger
+.RE
+.PP
 \fBRight\fR:
 .RS 4
 All icons will be right\-aligned with the width set in the \(oqinit\(cq file

--- a/nls/fluxbox-nls.hh
+++ b/nls/fluxbox-nls.hh
@@ -27,6 +27,7 @@ enum {
 	AlignCenter = 18,
 	AlignTop = 19,
 	AlignBottom = 20,
+	AlignRelativeSmart = 21,
 
 	BaseDisplaySet = 2,
 	BaseDisplayAborting = 1,

--- a/src/FbTk/Container.cc
+++ b/src/FbTk/Container.cc
@@ -324,7 +324,7 @@ void Container::repositionItems() {
     // if we have a max total size, then we must also resize ourself
     // within that bound
     Alignment align = alignment();
-    if (m_max_total_size && align != RELATIVE) {
+    if (m_max_total_size && (align != RELATIVE && align != RELATIVE_SMART)) {
         total_width = (max_width_per_client + borderW) * num_items - borderW;
         if (total_width > m_max_total_size) {
             total_width = m_max_total_size;
@@ -379,7 +379,7 @@ void Container::repositionItems() {
     unsigned int totalDemands = 0;
     std::vector<unsigned int> buttonDemands;
 
-    if (align == RELATIVE || total_width == m_max_total_size) {
+    if (align == RELATIVE_SMART && total_width == m_max_total_size) {
         buttonDemands.reserve(num_items);
         for (it = begin(); it != it_end; ++it) {
             buttonDemands.push_back((*it)->preferredWidth());
@@ -440,7 +440,7 @@ void Container::repositionItems() {
         // rotate the x and y coords
         tmpx = next_x;
         tmpy = -borderW;
-        if (align == RELATIVE && totalDemands) {
+        if ((align == RELATIVE || align == RELATIVE_SMART) && totalDemands) {
             tmpw = buttonDemands.at(i)*total_width/totalDemands + extra;
         } else {
             tmpw = max_width_per_client + extra;
@@ -469,6 +469,7 @@ unsigned int Container::maxWidthPerClient() const {
     case LEFT:
         return m_max_size_per_client;
         break;
+    case RELATIVE_SMART:
     case RELATIVE:
         if (size() == 0)
             return width();

--- a/src/FbTk/Container.hh
+++ b/src/FbTk/Container.hh
@@ -39,7 +39,7 @@ class Container: public FbWindow, public EventHandler, private NotCopyable {
 public:
     // LEFT, RIGHT => fixed total width, fixed icon size
     // RELATIVE => fixed total width, relative/variable icon size
-    enum Alignment { LEFT, CENTER, RIGHT, RELATIVE };
+    enum Alignment { LEFT, CENTER, RIGHT, RELATIVE, RELATIVE_SMART };
     typedef Button * Item;
     typedef const Button * ConstItem;
     typedef std::list<Item> ItemList;

--- a/src/IconbarTool.cc
+++ b/src/IconbarTool.cc
@@ -73,6 +73,8 @@ string FbTk::Resource<FbTk::Container::Alignment>::getString() const {
         return string("Left");
     if (m_value == FbTk::Container::RIGHT)
         return string("Right");
+    if (m_value == FbTk::Container::RELATIVE_SMART)
+        return string("RelativeSmart");
     return string("Relative");
 }
 
@@ -84,6 +86,8 @@ void FbTk::Resource<FbTk::Container::Alignment>::setFromString(const char *str) 
         m_value = FbTk::Container::RIGHT;
     else if (strcasecmp(str, "Relative") == 0)
         m_value = FbTk::Container::RELATIVE;
+    else if (strcasecmp(str, "RelativeSmart") == 0)
+        m_value = FbTk::Container::RELATIVE_SMART;
     else
         setDefaultValue();
 }
@@ -143,6 +147,7 @@ enum {
 
     L_LEFT,
     L_RELATIVE,
+    L_RELATIVE_SMART,
     L_RIGHT,
 };
 
@@ -163,6 +168,7 @@ void setupModeMenu(FbTk::Menu &menu, IconbarTool &handler) {
 
         _FB_XTEXT(Align, Left, "Left", "Align to the left"),
         _FB_XTEXT(Align, Relative, "Relative", "Align relative to the width"),
+        _FB_XTEXT(Align, RelativeSmart, "Relative (Smart)", "Align relative to the width, but let elements vary according to size of title"),
         _FB_XTEXT(Align, Right, "Right", "Align to the right"),
     };
 
@@ -181,6 +187,7 @@ void setupModeMenu(FbTk::Menu &menu, IconbarTool &handler) {
 
     menu.insertItem(new ToolbarAlignMenuItem(_labels[L_LEFT], handler, FbTk::Container::LEFT, saverc_cmd));
     menu.insertItem(new ToolbarAlignMenuItem(_labels[L_RELATIVE], handler, FbTk::Container::RELATIVE, saverc_cmd));
+    menu.insertItem(new ToolbarAlignMenuItem(_labels[L_RELATIVE_SMART], handler, FbTk::Container::RELATIVE_SMART, saverc_cmd));
     menu.insertItem(new ToolbarAlignMenuItem(_labels[L_RIGHT], handler, FbTk::Container::RIGHT, saverc_cmd));
 
     menu.insertItem(new FbTk::MenuSeparator());

--- a/src/IconbarTool.cc
+++ b/src/IconbarTool.cc
@@ -304,11 +304,21 @@ void IconbarTool::move(int x, int y) {
     m_icon_container.move(x, y);
 }
 
-void IconbarTool::resize(unsigned int width, unsigned int height) {
-    m_icon_container.resize(width, height);
+void IconbarTool::updateMaxSizes(unsigned int width, unsigned int height) {
     const unsigned int maxsize = (m_icon_container.orientation() & 1) ? height : width;
     m_icon_container.setMaxTotalSize(maxsize);
-    m_icon_container.setMaxSizePerClient(maxsize/std::max(1, m_icon_container.size()));
+
+    if(*m_rc_alignment == FbTk::Container::LEFT || *m_rc_alignment == FbTk::Container::RIGHT) {
+        *m_rc_client_width = FbTk::Util::clamp(*m_rc_client_width, 10, 400);
+        m_icon_container.setMaxSizePerClient(*m_rc_client_width);
+    } else {
+        m_icon_container.setMaxSizePerClient(maxsize/std::max(1, m_icon_container.size()));
+    }
+}
+
+void IconbarTool::resize(unsigned int width, unsigned int height) {
+    m_icon_container.resize(width, height);
+    updateMaxSizes(width, height);
     renderTheme();
 }
 
@@ -316,9 +326,7 @@ void IconbarTool::moveResize(int x, int y,
                              unsigned int width, unsigned int height) {
 
     m_icon_container.moveResize(x, y, width, height);
-    const unsigned int maxsize = (m_icon_container.orientation() & 1) ? height : width;
-    m_icon_container.setMaxTotalSize(maxsize);
-    m_icon_container.setMaxSizePerClient(maxsize/std::max(1, m_icon_container.size()));
+    updateMaxSizes(width, height);
     renderTheme();
 }
 
@@ -438,10 +446,8 @@ void IconbarTool::update(UpdateReason reason, Focusable *win) {
     }
 
     m_resizeSig_timer.start();
-    const unsigned int maxsize = (m_icon_container.orientation() & 1) ? height() : width();
-    m_icon_container.setMaxTotalSize(maxsize);
-    m_icon_container.setMaxSizePerClient(maxsize/std::max(1, m_icon_container.size()));
 
+    updateMaxSizes(width(), height());
     // unlock container and update graphics
     m_icon_container.setUpdateLock(false);
     m_icon_container.update();

--- a/src/IconbarTool.hh
+++ b/src/IconbarTool.hh
@@ -98,6 +98,7 @@ private:
     /// add icons to the list
     void updateList();
 
+    void updateMaxSizes(unsigned int width, unsigned int height);
     /// called when the list emits a signal
     void update(UpdateReason reason, Focusable *win);
 


### PR DESCRIPTION
This PR solves following:

* iconbar alignment = Left/Right did not really work with sizes (I may be wrong, it is a while since I did these changes)
* iconbar alignment = Relative was changed to adapt to title length, however I imagine not all (including myself) may like this feature, therefore it is changed and denoted RelativeSmart. So Relative is being restored to what it has always been.
