### PR TITLE
STACKTOP/STACKBOTTOM and STACKLEFT/STACKRIGHT rows/cols adjustment

### DIFF
--- a/src/WorkspaceCmd.cc
+++ b/src/WorkspaceCmd.cc
@@ -473,6 +473,17 @@ void ArrangeWindowsCmd::execute() {
         std::swap(cols, rows);
     }
 
+    // In stacking modes, still approximate the screen's aspect ratio
+    // For STACKTOP, STACKBOTTOM: cols = 1.5 * rows
+    // For STACKLEFT, STACKRIGHT: rows = 1.5 * cols
+    if ((m_tile_method == STACKTOP) || (m_tile_method == STACKBOTTOM)) {
+        rows = int(sqrt(ceil((float)win_count / 1.5))); // truncate to lower
+        cols = int(0.99 + float(win_count) / float(rows));
+    } else if ((m_tile_method == STACKLEFT) || (m_tile_method == STACKRIGHT)) {
+        cols = int(sqrt(ceil((float)win_count / 1.5))); // truncate to lower
+        rows = int(0.99 + float(win_count) / float(cols));
+    }
+
     // Stacked mode only uses half the screen for tiled windows, so adjust
     // offset to half the screen (horizontal or vertical depending on 
     // stacking mode)


### PR DESCRIPTION
Greetings,

This is a continuation of the pull request https://github.com/fluxbox/fluxbox/pull/42.

I reviewed my approach according to @mark-t's suggestions and ended up forcing 1.5 (instead of 2) ratio between rows and cols in STACKTOP/STACKBOTTOM and STACKLEFT/STACKRIGHT tiling modes.

This is the best trade-off that I found for window's content readability, considering different monitor aspect ratios.

Please review carefully, since this modification has effects only when more than 5 windows are simultaneously open on the current workspace, which is rather uncommon for my typical workflow.

Cheers

--
Alessandro