### PR TITLE
Fix fbrun completion search for last directory in PATH

### DIFF
--- a/util/fbrun/FbRun.cc
+++ b/util/fbrun/FbRun.cc
@@ -508,8 +508,8 @@ void FbRun::tabCompleteApps() {
             first_run = false;
             std::string path = getenv("PATH");
             FbTk::Directory dir;
-            for (unsigned int l = 0, r = 0; r < path.size(); ++r) {
-                if ((path.at(r) == ':' || r == path.size() - 1) && r - l > 1) {
+            for (unsigned int l = 0, r = 0; r <= path.size(); ++r) {
+                if ((r == path.size() || path.at(r) == ':') && r - l > 1) {
                     dir.open(path.substr(l, r - l).c_str());
                     prefix = dir.name() + (*dir.name().rbegin() == '/' ? "" : "/");
                     int n = dir.entries();


### PR DESCRIPTION
FbRun completion doesn't display variants of executables located in directory of $PATH which is not followed by colon, i.e. last directory or single directory. E.g.:

`$ PATH=/bin:/sbin fbrun`
^ fbrun displays variants only from /bin

`$ PATH=/bin fbrun`
^ fbrun doesn't display variants at all.

But
`$ PATH=/bin:/sbin: fbrun`
^ works correctly.

Bug is caused by wrong end-of-string detection condition.
This commit fixes the issue.