### PR TITLE
fix: Warn & attempt fallback for unsupported locale in text property conversion

### DIFF
--- a/src/fluxbox.cc
+++ b/src/fluxbox.cc
@@ -862,7 +862,7 @@ void Fluxbox::handleClientMessage(XClientMessageEvent &ce) {
     if (ce.message_type)
         atom = XGetAtomName(FbTk::App::instance()->display(), ce.message_type);
 
-    fbdbg<<__FILE__<<"("<<__LINE__<<"): ClientMessage. data.l[0]=0x"<<hex<<ce.data.l[0]<<
+    fbdbg << "ClientMessage. data.l[0]=0x"<<hex<<ce.data.l[0]<<
         "  message_type=0x"<<ce.message_type<<dec<<" = \""<<atom<<"\""<<endl;
 
     if (ce.message_type && atom) XFree((char *) atom);
@@ -1151,7 +1151,7 @@ void Fluxbox::save_rc() {
     XrmPutFileDatabase(old_rc, dbfile.c_str());
     XrmDestroyDatabase(old_rc);
 
-    fbdbg<<__FILE__<<"("<<__LINE__<<"): ------------ SAVING DONE"<<endl;
+    fbdbg <<"------------ SAVING DONE"<<endl;
 
 }
 


### PR DESCRIPTION
In a new installation (OpenSUSE Tumbleweed), I somehow ended up with a valid locale (for things like date formats, etc.) that however Xwindows did not know about (because it has its own locale repository in /usr/share/X11/locale, different from the repository in /usr/share/locale). This had the very odd side effect that Fluxbox pretty much worked almost entirely normally, but it would not pick up Extended Window Manager Hints (!). It was a bit maddening to debug, so this PR issues a warning in this circumstance, and attempts to fall back to a reasonable stopgap behavior (which is to do no conversion of the results of the XGetTextProperty -- this may well be wrong, but it's likely to produce something at least recognizable).

I gather the official repository is still git.fluxbox.org, but I don't think there's any convenient way to issue a PR there, which is why I am still submitting it here. This is a pretty minor change but it could save some other poor soul quite a few hours, so I hope it can go in.

Since I was using the debugging log considerably, I also took the opportunity to remove redundant file and line references (they are put in automagically by fbdbg and were also being explicitly written in some fbdbg invocations). I also clarified the use of the "helper" in FbWindow::textProperty by changing its name -- I was getting double frees before I realized what that did.