### PR TITLE
feat: Allow tab placement to be controlled per window via apps file

### DIFF
--- a/doc/asciidoc/fluxbox-apps.txt
+++ b/doc/asciidoc/fluxbox-apps.txt
@@ -174,6 +174,16 @@ Button, Close Button, Menu Button, Sticky Button, Shade Button, External Tabs, F
 *[Tab]* {'bool'}::
     Whether the window has tabs enabled.
 
+*[TabPlacement]* {'position'}::
+    Specify where the tab(s) for the window should be placed (assuming that
+    external tabs are being used). The 'position' may be any of *Top*,
+    *TopLeft*, *TopRight*, *Bottom*, *BottomLeft*, *BottomRight*, *Left*,
+    *LeftTop*, *LeftBottom*, *Right*, *RightTop*, or *RightBottom*. The values
+    with only one directional component mean for the tabs to be centered on
+    the specified side. Note that if this setting is not given, the
+    general tab placement for the window's screen, specified by the
+    *tabPlacement* resource in the rc file (see fluxbox(1) for details), is used.
+
 *[FocusNewWindow]* {'bool'}::
     *DEPRECATED!* Please use FocusProtection "Gain" or "Refuse" instead.;;
     If enabled, a new window will grab X focus as soon as it is opened.

--- a/doc/fluxbox-apps.5.in
+++ b/doc/fluxbox-apps.5.in
@@ -1,7 +1,7 @@
 '\" t
 .\"     Title: fluxbox-apps
 .\"    Author: Jim Ramsay <i.am@jimramsay.com>
-.\" Generator: DocBook XSL Stylesheets v1.78.1 <http://docbook.sf.net/>
+.\" Generator: DocBook XSL Stylesheets v1.79.1 <http://docbook.sf.net/>
 .\"      Date: 08 February 2015
 .\"    Manual: Fluxbox Manual
 .\"    Source: fluxbox-apps.txt
@@ -52,7 +52,9 @@ The file is made up of two main types of sections, apps and groups, detailed bel
 .PP
 These sections begin with a line of the format
 .RS 4
-\fB[app]\fR\fB(\fR\fIpattern\fR\fB)\fR\fB{\fR\fIcount\fR\fB}\fR
+\fB[app]\fR
+\fB(\fR\fIpattern\fR\fB)\fR
+\fB{\fR\fIcount\fR\fB}\fR
 .RE
 .sp
 The \fIpattern\fR can be one or more patterns which match windows\&. For more details, see \fBCLIENT PATTERNS\fR\&. If you specify more than one \fIpattern\fR, they must ALL match for the settings to be applied\&.
@@ -76,7 +78,8 @@ The primary purpose of \fB[group]\fR sections is to group windows together\&. Al
 .PP
 These sections begin with a line of the format
 .RS 4
-\fB[group]\fR\fB(\fR\fIpattern\fR\fB)\fR
+\fB[group]\fR
+\fB(\fR\fIpattern\fR\fB)\fR
 .RE
 .sp
 Where the \fIpattern\fR item is optional\&. If specified, this pattern must match for the group to take effect\&. It is common to use non\-window\-specific patterns such as \fB(workspace)\fR here\&. See \fBCLIENT PATTERNS\fR for more details\&.
@@ -85,7 +88,8 @@ This is followed by any number of \fB[app]\fR lines\&. These have a similar form
 .PP
 Like this
 .RS 4
-\fB[app]\fR\fB(\fR\fIpattern\fR\fB)\fR
+\fB[app]\fR
+\fB(\fR\fIpattern\fR\fB)\fR
 .RE
 .sp
 This section may also contain settings that are applied to every window in the group\&. See the \fBSETTINGS\fR section for details\&.
@@ -100,7 +104,8 @@ These settings may be stored in the \(oqapps\(cq file\&. A settings line must ap
 .PP
 The general format is
 .RS 4
-\fB[\fR\fIsetting\fR\fB]\fR\fB{\fR\fIvalue\fR\fB}\fR
+\fB[\fR\fIsetting\fR\fB]\fR
+\fB{\fR\fIvalue\fR\fB}\fR
 .RE
 .sp
 All allowed values are described below, except for \fIbool\fR which can simply have the value \fByes\fR or \fBno\fR, which enables or disables the associated setting, respectively\&.
@@ -207,6 +212,27 @@ Whether the window is Shaded (rolled\-up) or not\&.
 \fB[Tab]\fR {\fIbool\fR}
 .RS 4
 Whether the window has tabs enabled\&.
+.RE
+.PP
+\fB[TabPlacement]\fR {\fIposition\fR}
+.RS 4
+Specify where the tab(s) for the window should be placed (assuming that external tabs are being used)\&. The
+\fIposition\fR
+may be any of
+\fBTop\fR,
+\fBTopLeft\fR,
+\fBTopRight\fR,
+\fBBottom\fR,
+\fBBottomLeft\fR,
+\fBBottomRight\fR,
+\fBLeft\fR,
+\fBLeftTop\fR,
+\fBLeftBottom\fR,
+\fBRight\fR,
+\fBRightTop\fR, or
+\fBRightBottom\fR\&. The values with only one directional component mean for the tabs to be centered on the specified side\&. Note that if this setting is not given, the general tab placement for the window\(cqs screen, specified by the
+\fBtabPlacement\fR
+resource in the rc file (see fluxbox(1) for details), is used\&.
 .RE
 .PP
 \fB[FocusNewWindow]\fR {\fIbool\fR}

--- a/src/FbWinFrame.cc
+++ b/src/FbWinFrame.cc
@@ -37,10 +37,12 @@
 #include "FbTk/CompareEqual.hh"
 #include "FbTk/TextUtils.hh"
 #include "FbTk/STLUtil.hh"
+#include "FbTk/Util.hh"
 
 #include <X11/X.h>
 
 #include <algorithm>
+#include <cstring>
 
 using std::max;
 using std::mem_fun;
@@ -54,6 +56,28 @@ enum { UNFOCUS = 0, FOCUS, PRESSED };
 
 const int s_button_size = 26;
 const long s_mask = ButtonPressMask | ButtonReleaseMask | ButtonMotionMask | EnterWindowMask | LeaveWindowMask;
+
+struct TabPlacementString {
+    FbWinFrame::TabPlacement placement;
+    const char* str;
+};
+
+const TabPlacementString _PLACEMENT_STRINGS[] = {
+    { FbWinFrame::DEFER_TO_SCREEN, "DeferToScreenTabPlacement" }, // presumably not used
+    { FbWinFrame::TOPLEFT, "TopLeft" },
+    { FbWinFrame::TOP, "Top" },
+    { FbWinFrame::TOPRIGHT, "TopRight" },
+    { FbWinFrame::BOTTOMLEFT, "BottomLeft" },
+    { FbWinFrame::BOTTOM, "Bottom" },
+    { FbWinFrame::BOTTOMRIGHT, "BottomRight" },
+    { FbWinFrame::LEFTBOTTOM, "LeftBottom" },
+    { FbWinFrame::LEFT, "Left" },
+    { FbWinFrame::LEFTTOP, "LeftTop" },
+    { FbWinFrame::RIGHTBOTTOM, "RightBottom" },
+    { FbWinFrame::RIGHT, "Right" },
+    { FbWinFrame::RIGHTTOP, "RightTop" },
+    { FbWinFrame::UNPARSEABLE, "<Error in parsing TabPlacement>" }
+};
 
 const struct {
     FbWinFrame::TabPlacement where;
@@ -106,6 +130,24 @@ void bg_pm_or_color(FbTk::FbWindow& win, const Pixmap& pm, const FbTk::Color& co
 
 } // end anonymous
 
+std::string FbWinFrame::nameOfTabPlacement(FbWinFrame::TabPlacement place) {
+    size_t i = (place == FbTk::Util::clamp(place, FbWinFrame::DEFER_TO_SCREEN,
+                                                  FbWinFrame::RIGHTTOP))
+               ? place
+               : FbWinFrame::DEFAULT;
+    return _PLACEMENT_STRINGS[i].str;
+}
+
+FbWinFrame::TabPlacement FbWinFrame::tabPlacementNamed(const char* name) {
+    static size_t n_tps = sizeof(_PLACEMENT_STRINGS)/sizeof(_PLACEMENT_STRINGS[0]);
+    for (size_t i = 0; i < n_tps; ++i) {
+        if (strcasecmp(name, _PLACEMENT_STRINGS[i].str) == 0) {
+            return _PLACEMENT_STRINGS[i].placement;
+        }
+    }
+    return FbWinFrame::UNPARSEABLE;
+}
+
 FbWinFrame::FbWinFrame(BScreen &screen, unsigned int client_depth,
                        WindowState &state,
                        FocusableTheme<FbWinFrameTheme> &theme):
@@ -143,6 +185,7 @@ FbWinFrame::FbWinFrame(BScreen &screen, unsigned int client_depth,
     m_use_handle(true),
     m_visible(false),
     m_tabmode(screen.getDefaultInternalTabs()?INTERNAL:EXTERNAL),
+    m_tab_placement(FbWinFrame::DEFER_TO_SCREEN),
     m_active_orig_client_bw(0),
     m_need_render(true),
     m_button_size(1),
@@ -217,6 +260,16 @@ bool FbWinFrame::setTabMode(TabMode tabmode) {
     }
 
     return ret;
+}
+
+FbWinFrame::TabPlacement FbWinFrame::tabPlacement() const {
+  if (m_tab_placement == DEFER_TO_SCREEN) return m_screen.getTabPlacement();
+  return m_tab_placement;
+}
+
+void FbWinFrame::setTabPlacement(FbWinFrame::TabPlacement place) {
+  m_tab_placement = place;
+  // do we need to do anything here to ensure redraw?
 }
 
 void FbWinFrame::hide() {
@@ -297,14 +350,13 @@ void FbWinFrame::moveResize(int x, int y, unsigned int width, unsigned int heigh
     m_state.saveGeometry(window().x(), window().y(),
                          window().width(), window().height());
 
-    if (move || (resize && m_screen.getTabPlacement() != TOPLEFT &&
-                           m_screen.getTabPlacement() != LEFTTOP))
+    if (move || (resize && tabPlacement() != TOPLEFT && tabPlacement() != LEFTTOP))
         alignTabs();
 
     if (resize) {
         if (m_tabmode == EXTERNAL) {
             unsigned int s = width;
-            if (!s_place[m_screen.getTabPlacement()].is_horizontal) {
+            if (!s_place[tabPlacement()].is_horizontal) {
                 s = height;
             }
             m_tab_container.setMaxTotalSize(s);
@@ -320,7 +372,7 @@ void FbWinFrame::quietMoveResize(int x, int y,
                          window().width(), window().height());
     if (m_tabmode == EXTERNAL) {
         unsigned int s = width;
-        if (!s_place[m_screen.getTabPlacement()].is_horizontal) {
+        if (!s_place[tabPlacement()].is_horizontal) {
             s = height;
         }
         m_tab_container.setMaxTotalSize(s);
@@ -345,7 +397,7 @@ void FbWinFrame::alignTabs() {
     int tab_x = x();
     int tab_y = y();
 
-    TabPlacement p = m_screen.getTabPlacement();
+    TabPlacement p = tabPlacement();
     if (orig_orient != s_place[p].orient) {
         tabs.hide();
     }
@@ -870,7 +922,7 @@ void FbWinFrame::reconfigure() {
     if (m_tabmode == EXTERNAL) {
         unsigned int h = buttonHeight();
         unsigned int w = m_tab_container.width();
-        if (!s_place[m_screen.getTabPlacement()].is_horizontal) {
+        if (!s_place[tabPlacement()].is_horizontal) {
             w = m_tab_container.height();
             std::swap(w, h);
         }
@@ -1505,7 +1557,7 @@ void FbWinFrame::gravityTranslate(int &x, int &y,
 int FbWinFrame::widthOffset() const {
     if (m_tabmode != EXTERNAL || !m_use_tabs)
         return 0;
-    if (s_place[m_screen.getTabPlacement()].is_horizontal) {
+    if (s_place[tabPlacement()].is_horizontal) {
         return 0;
     }
     return m_tab_container.width() + m_window.borderWidth();
@@ -1515,7 +1567,7 @@ int FbWinFrame::heightOffset() const {
     if (m_tabmode != EXTERNAL || !m_use_tabs)
         return 0;
 
-    if (!s_place[m_screen.getTabPlacement()].is_horizontal) {
+    if (!s_place[tabPlacement()].is_horizontal) {
         return 0;
     }
     return m_tab_container.height() + m_window.borderWidth();
@@ -1524,7 +1576,7 @@ int FbWinFrame::heightOffset() const {
 int FbWinFrame::xOffset() const {
     if (m_tabmode != EXTERNAL || !m_use_tabs)
         return 0;
-    TabPlacement p = m_screen.getTabPlacement();
+    TabPlacement p = tabPlacement();
     if (p == LEFTTOP || p == LEFT || p == LEFTBOTTOM) {
         return m_tab_container.width() + m_window.borderWidth();
     }
@@ -1534,7 +1586,7 @@ int FbWinFrame::xOffset() const {
 int FbWinFrame::yOffset() const {
     if (m_tabmode != EXTERNAL || !m_use_tabs)
         return 0;
-    TabPlacement p = m_screen.getTabPlacement();
+    TabPlacement p = tabPlacement();
     if (p == TOPLEFT || p == TOP || p == TOPRIGHT) {
         return m_tab_container.height() + m_window.borderWidth();
     }

--- a/src/FbWinFrame.hh
+++ b/src/FbWinFrame.hh
@@ -58,15 +58,22 @@ public:
 
    /// Toolbar placement on the screen
     enum TabPlacement{
+        // Typically we just take the screen setting
+        DEFER_TO_SCREEN = 0,
         // top and bottom placement
         TOPLEFT = 1, TOP, TOPRIGHT,
         BOTTOMLEFT, BOTTOM, BOTTOMRIGHT,
         // left and right placement
         LEFTBOTTOM, LEFT, LEFTTOP,
         RIGHTBOTTOM, RIGHT, RIGHTTOP,
+        // Couldn't parse a placement
+        UNPARSEABLE,
 
         DEFAULT = TOPLEFT
     };
+
+    static std::string nameOfTabPlacement(TabPlacement place);
+    static TabPlacement tabPlacementNamed(const char *name);
 
     /// create a top level window
     FbWinFrame(BScreen &screen, unsigned int client_depth, WindowState &state,
@@ -108,6 +115,8 @@ public:
 
     void setFocusTitle(const FbTk::BiDiString &str) { m_label.setText(str); }
     bool setTabMode(TabMode tabmode);
+    TabPlacement tabPlacement() const;
+    void setTabPlacement(TabPlacement place);
     void updateTabProperties() { alignTabs(); }
 
     /// Alpha settings
@@ -345,6 +354,7 @@ private:
     //@}
 
     TabMode m_tabmode;
+    TabPlacement m_tab_placement;
 
     unsigned int m_active_orig_client_bw;
 

--- a/src/Remember.hh
+++ b/src/Remember.hh
@@ -68,6 +68,7 @@ public:
         REM_SHADEDSTATE,
         REM_STUCKSTATE,
         //REM_TABSTATE, ... external tabs disabled atm
+        REM_TABPLACEMENT,
         REM_WORKSPACE,
         REM_HEAD,
         REM_ALPHA,

--- a/src/ScreenResource.cc
+++ b/src/ScreenResource.cc
@@ -21,57 +21,20 @@
 
 #include "ScreenResource.hh"
 #include "fluxbox.hh"
-#include "FbTk/Util.hh"
-#include <cstring>
-
-namespace {
-
-struct TabPlacementString {
-    FbWinFrame::TabPlacement placement;
-    const char* str;
-};
-
-const TabPlacementString _PLACEMENT_STRINGS[] = {
-    { FbWinFrame::TOPLEFT, "TopLeft" },
-    { FbWinFrame::TOP, "Top" },
-    { FbWinFrame::TOPRIGHT, "TopRight" },
-    { FbWinFrame::BOTTOMLEFT, "BottomLeft" },
-    { FbWinFrame::BOTTOM, "Bottom" },
-    { FbWinFrame::BOTTOMRIGHT, "BottomRight" },
-    { FbWinFrame::LEFTBOTTOM, "LeftBottom" },
-    { FbWinFrame::LEFT, "Left" },
-    { FbWinFrame::LEFTTOP, "LeftTop" },
-    { FbWinFrame::RIGHTBOTTOM, "RightBottom" },
-    { FbWinFrame::RIGHT, "Right" },
-    { FbWinFrame::RIGHTTOP, "RightTop" }
-};
-
-}
 
 namespace FbTk {
 
 template<>
 std::string FbTk::Resource<FbWinFrame::TabPlacement>::
 getString() const {
-
-    size_t i = (m_value == FbTk::Util::clamp(m_value, FbWinFrame::TOPLEFT, FbWinFrame::RIGHTTOP)
-                ? m_value 
-                : FbWinFrame::DEFAULT) - 1;
-    return _PLACEMENT_STRINGS[i].str;
+    return FbWinFrame::nameOfTabPlacement(m_value);
 }
 
 template<>
 void FbTk::Resource<FbWinFrame::TabPlacement>::
 setFromString(const char *strval) {
-
-    size_t i;
-    for (i = 0; i < sizeof(_PLACEMENT_STRINGS)/sizeof(_PLACEMENT_STRINGS[0]); ++i) {
-        if (strcasecmp(strval, _PLACEMENT_STRINGS[i].str) == 0) {
-            m_value = _PLACEMENT_STRINGS[i].placement;
-            return;
-        }
-    }
-    setDefaultValue();
+    m_value = FbWinFrame::tabPlacementNamed(strval);
+    if (m_value == FbWinFrame::UNPARSEABLE) setDefaultValue();
 }
 
 } // end namespace FbTk


### PR DESCRIPTION
See fluxbox-apps(5) for details, but it's about what you would expect: lines like

`[TabPlacement] {BottomRight}`

are now allowed and respected in the apps file. So not all windows have to have their tabs in the same place. This is basically the feature I was working up to in the long series of PRs I have recently made, so I will give it a rest now for a while.