### PR TITLE
Fix infinite loop in Menu::cycleitems()

### DIFF
--- a/src/FbTk/Menu.cc
+++ b/src/FbTk/Menu.cc
@@ -320,15 +320,24 @@ void Menu::lower() {
 
 void Menu::cycleItems(bool reverse) {
 
-    if (m_items.empty())
-        return;
-
-    int offset = reverse ? -1 : 1;
     int l = m_items.size();
-    int i = m_active_index;
+    int i;
+    int offset = reverse ? -1 : 1;
     size_t ignore;
 
-    for (i += offset; i != m_active_index; i += offset ) {
+    // check if there is _any_ selectable item
+    for (i = 0; i < l; i++) {
+        if (isItemSelectable(i)) {
+            break;
+        }
+    }
+
+    // no selectable item
+    if (i >= l) {
+        return;
+    }
+
+    for (i = m_active_index + offset; i != m_active_index; i += offset ) {
         if (i < 0) {
             i = l - 1;
         } else if (i >= l) {


### PR DESCRIPTION
When a menu contains no selectable item (example given: a "list" of user
styles and the only available one is already selected), cycling through
the menu will lead to an infinite loop and thus a disfunctional fluxbox.

This commit addresses the issue by checking if there is any selectable
item before entering the cycling stage.

Discovered by Sébastien Ballet[1].

[1]: https://sourceforge.net/p/fluxbox/bugs/1185/