### PR TITLE
chore: remove compiler warnings

### DIFF
--- a/src/FbTk/CompareEqual.hh
+++ b/src/FbTk/CompareEqual.hh
@@ -27,7 +27,7 @@ namespace FbTk {
 
 /// @brief compares one class function with a value type
 template <typename ClassType, typename ValueType>
-class CompareEqual_base: public std::unary_function<ClassType, bool> {
+class CompareEqual_base {
 public:
     typedef ValueType (ClassType::* Action)() const;
     typedef ValueType Value;

--- a/src/FbTk/Compose.hh
+++ b/src/FbTk/Compose.hh
@@ -29,16 +29,12 @@ namespace FbTk {
 /// Composes two functions into one.
 /// Uses Arg for type B and then calls type A
 template <class A, class B>
-class Compose_base: public std::unary_function<typename B::argument_type, typename A::result_type> {
+class Compose_base {
 public:
-    typedef typename A::result_type ResultTypeA;
-    typedef typename A::argument_type ArgumentTypeA;
-    typedef typename B::result_type ResultTypeB;
-    typedef typename B::argument_type ArgumentTypeB;
-
     Compose_base(const A &a, const B &b):m_a(a), m_b(b) { }
-    ResultTypeA operator () (const ArgumentTypeB &arg) const {
-        return m_a(m_b(arg));
+    template <class ARG>
+    auto operator () (const ARG& arg) const {
+      return m_a(m_b(arg));
     }
 
 private:

--- a/src/FbTk/Container.cc
+++ b/src/FbTk/Container.cc
@@ -32,6 +32,8 @@
 #include <algorithm>
 #include <vector>
 
+using namespace std::placeholders;
+
 namespace FbTk {
 
 typedef CompareEqual_base<FbWindow, Window> CompareWindow;
@@ -491,27 +493,27 @@ unsigned int Container::maxWidthPerClient() const {
     return 1;
 }
 
-void Container::for_each(std::mem_fun_t<void, FbWindow> function) {
+void Container::for_each(std::function<void(Item)> function) {
     std::for_each(begin(), end(), function);
 }
 
 void Container::setAlpha(int alpha) {
     FbWindow::setAlpha(alpha);
-    STLUtil::forAll(m_item_list, std::bind2nd(std::mem_fun(&Button::setAlpha), alpha));
+    STLUtil::forAll(m_item_list, std::bind(std::mem_fn(&Button::setAlpha), _1, alpha));
 }
 
 void Container::parentMoved() {
     FbWindow::parentMoved();
-    STLUtil::forAll(m_item_list, std::mem_fun(&Button::parentMoved));
+    STLUtil::forAll(m_item_list, std::mem_fn(&Button::parentMoved));
 }
 
 void Container::invalidateBackground() {
     FbWindow::invalidateBackground();
-    STLUtil::forAll(m_item_list, std::mem_fun(&Button::invalidateBackground));
+    STLUtil::forAll(m_item_list, std::mem_fn(&Button::invalidateBackground));
 }
 
 void Container::clear() {
-    STLUtil::forAll(m_item_list, std::mem_fun(&Button::clear));
+    STLUtil::forAll(m_item_list, std::mem_fn(&Button::clear));
 }
 
 void Container::setOrientation(Orientation orient) {
@@ -519,7 +521,7 @@ void Container::setOrientation(Orientation orient) {
         return;
 
     FbWindow::invalidateBackground();
-    STLUtil::forAll(m_item_list, std::bind2nd(std::mem_fun(&Button::setOrientation), orient));
+    STLUtil::forAll(m_item_list, std::bind(std::mem_fn(&Button::setOrientation),_1, orient));
 
     if (((m_orientation == ROT0 || m_orientation == ROT180) &&
         (orient == ROT90 || orient == ROT270)) ||

--- a/src/FbTk/Container.hh
+++ b/src/FbTk/Container.hh
@@ -90,7 +90,7 @@ public:
     unsigned int maxWidthPerClient() const;
     bool updateLock() const { return m_update_lock; }
 
-    void for_each(std::mem_fun_t<void, FbWindow> function);
+    void for_each(std::function<void(Item)> function);
     void setAlpha(int alpha); // set alpha on all windows
 
     ItemList::iterator begin() { return m_item_list.begin(); }

--- a/src/FbTk/MemFun.hh
+++ b/src/FbTk/MemFun.hh
@@ -56,7 +56,7 @@ MemFun( Object& obj, ReturnType (Object:: *action)() ) {
 
 /// One argument functor
 template <typename ReturnType, typename Object, typename Arg1>
-class MemFun1: public std::unary_function<Arg1, ReturnType> {
+class MemFun1 {
 public:
     typedef ReturnType (Object:: *Action)(Arg1);
 
@@ -83,7 +83,7 @@ MemFun( Object& obj, ReturnType (Object:: *action)(Arg1) ) {
 
 /// Two argument functor
 template <typename ReturnType, typename Object, typename Arg1, typename Arg2>
-class MemFun2: public std::binary_function<Arg1, Arg2, ReturnType> {
+class MemFun2 {
 public:
     typedef ReturnType (Object:: *Action)(Arg1,Arg2);
 

--- a/src/FbTk/Select2nd.hh
+++ b/src/FbTk/Select2nd.hh
@@ -27,7 +27,7 @@
 namespace FbTk {
 
 template <class A>
-class Select2nd:public std::unary_function<A, typename A::second_type> {
+class Select2nd {
 public:
     typename A::second_type operator () (const A &arg) const {
         return arg.second;

--- a/src/FbWinFrame.cc
+++ b/src/FbWinFrame.cc
@@ -43,7 +43,7 @@
 #include <algorithm>
 
 using std::max;
-using std::mem_fun;
+using std::mem_fn;
 using std::string;
 
 using FbTk::STLUtil::forAll;
@@ -405,7 +405,7 @@ void FbWinFrame::notifyMoved(bool clear) {
 
     if ((m_tabmode == EXTERNAL && m_use_tabs) || m_use_titlebar) {
         m_tab_container.parentMoved();
-        m_tab_container.for_each(mem_fun(&FbTk::Button::parentMoved));
+        m_tab_container.for_each(mem_fn(&FbTk::Button::parentMoved));
     }
 
     if (m_use_titlebar) {
@@ -414,8 +414,8 @@ void FbWinFrame::notifyMoved(bool clear) {
 
         m_titlebar.parentMoved();
 
-        forAll(m_buttons_left, mem_fun(&FbTk::Button::parentMoved));
-        forAll(m_buttons_right, mem_fun(&FbTk::Button::parentMoved));
+        forAll(m_buttons_left, mem_fn(&FbTk::Button::parentMoved));
+        forAll(m_buttons_right, mem_fn(&FbTk::Button::parentMoved));
     }
 
     if (m_use_handle) {
@@ -434,8 +434,8 @@ void FbWinFrame::clearAll() {
 
     if  (m_use_titlebar) {
         redrawTitlebar();
-        forAll(m_buttons_left, mem_fun(&FbTk::Button::clear));
-        forAll(m_buttons_right, mem_fun(&FbTk::Button::clear));
+        forAll(m_buttons_left, mem_fn(&FbTk::Button::clear));
+        forAll(m_buttons_right, mem_fn(&FbTk::Button::clear));
     } else if (m_tabmode == EXTERNAL && m_use_tabs)
         m_tab_container.clear();
 

--- a/src/IconbarTool.cc
+++ b/src/IconbarTool.cc
@@ -60,6 +60,8 @@ using std::string;
 using std::list;
 using std::endl;
 
+using namespace std::placeholders;
+
 namespace FbTk {
 
 template<>
@@ -367,13 +369,13 @@ void IconbarTool::setMode(string mode) {
                                            mode + " (iconhidden=no)"));
     if (m_winlist.get()) {
         m_winlist->addSig().connect(
-                    std::bind1st(FbTk::MemFun(*this, &IconbarTool::update), LIST_ADD)
+                    std::bind(FbTk::MemFun(*this, &IconbarTool::update), LIST_ADD, _1)
                 );
         m_winlist->removeSig().connect(
-                    std::bind1st(FbTk::MemFun(*this, &IconbarTool::update), LIST_REMOVE)
+                    std::bind(FbTk::MemFun(*this, &IconbarTool::update), LIST_REMOVE, _1)
                 );
         m_winlist->addSig().connect(
-                    std::bind1st(FbTk::MemFun(*this, &IconbarTool::update), LIST_ORDER)
+                    std::bind(FbTk::MemFun(*this, &IconbarTool::update), LIST_ORDER, _1)
                 );
         m_winlist->resetSig().connect(FbTk::MemFunBind(
                         *this, &IconbarTool::update, LIST_RESET, static_cast<Focusable *>(0)
@@ -518,7 +520,7 @@ void IconbarTool::updateSizing() {
     m_icon_container.setBorderColor(m_theme.border().color());
 
     FbTk::STLUtil::forAll(m_icons, 
-            FbTk::Compose(std::mem_fun(&IconButton::reconfigTheme), 
+            FbTk::Compose(std::mem_fn(&IconButton::reconfigTheme), 
                 FbTk::Select2nd<IconMap::value_type>()));
 
 }

--- a/src/Screen.cc
+++ b/src/Screen.cc
@@ -133,12 +133,13 @@ using std::make_pair;
 using std::pair;
 using std::list;
 using std::vector;
-using std::mem_fun;
-using std::bind2nd;
+using std::mem_fn;
 using std::equal_to;
 
 using std::hex;
 using std::dec;
+
+using namespace std::placeholders;
 
 static bool running = true;
 namespace {
@@ -750,12 +751,12 @@ void BScreen::reconfigure() {
     // reconfigure workspaces
     for_each(m_workspaces_list.begin(),
              m_workspaces_list.end(),
-             mem_fun(&Workspace::reconfigure));
+             mem_fn(&Workspace::reconfigure));
 
     // reconfigure Icons
     for_each(m_icon_list.begin(),
              m_icon_list.end(),
-             mem_fun(&FluxboxWindow::reconfigure));
+             mem_fn(&FluxboxWindow::reconfigure));
 
     imageControl().cleanCache();
     // notify objects that the screen is reconfigured
@@ -849,7 +850,7 @@ void BScreen::removeIcon(FluxboxWindow *w) {
 
     Icons::iterator erase_it = find_if(iconList().begin(),
                                        iconList().end(),
-                                       bind2nd(equal_to<FluxboxWindow *>(), w));
+                                       std::bind(equal_to<FluxboxWindow *>(), _1, w));
     // no need to send iconlist signal if we didn't
     // change the iconlist
     if (erase_it != m_icon_list.end()) {
@@ -884,7 +885,7 @@ void BScreen::removeClient(WinClient &client) {
     // remove any grouping this is expecting
     Groupables::iterator erase_it = find_if(m_expecting_groups.begin(),
                                             m_expecting_groups.end(),
-                                            Compose(bind2nd(equal_to<WinClient *>(), &client),
+                                            Compose(std::bind(equal_to<WinClient *>(), _1, &client),
                                                     Select2nd<Groupables::value_type>()));
 
     if (erase_it != m_expecting_groups.end())
@@ -1473,7 +1474,7 @@ void BScreen::shutdown() {
     m_focus_control->shutdown();
     for_each(m_workspaces_list.begin(),
              m_workspaces_list.end(),
-             mem_fun(&Workspace::shutdown));
+             mem_fn(&Workspace::shutdown));
 }
 
 

--- a/src/Toolbar.cc
+++ b/src/Toolbar.cc
@@ -72,6 +72,8 @@ using std::list;
 
 using FbTk::STLUtil::forAll;
 
+using namespace std::placeholders;
+
 namespace {
 
 const struct { 
@@ -366,9 +368,9 @@ void Toolbar::screenChanged(BScreen &screen) {
 }
 
 void Toolbar::relayout() {
-    forAll(m_item_list, std::mem_fun(&ToolbarItem::updateSizing));
+    forAll(m_item_list, std::mem_fn(&ToolbarItem::updateSizing));
     rearrangeItems();
-    forAll(m_item_list, std::bind2nd(std::mem_fun(&ToolbarItem::renderTheme), alpha()));
+    forAll(m_item_list, std::bind(std::mem_fn(&ToolbarItem::renderTheme), _1, alpha()));
 }
 
 void Toolbar::reconfigure() {
@@ -734,7 +736,7 @@ void Toolbar::setPlacement(Toolbar::Placement where) {
         break;
     }
 
-    forAll(m_item_list, std::bind2nd(std::mem_fun(&ToolbarItem::setOrientation), orient));
+    forAll(m_item_list, std::bind(std::mem_fn(&ToolbarItem::setOrientation), _1, orient));
 }
 
 void Toolbar::updateVisibleState() {
@@ -749,7 +751,7 @@ void Toolbar::toggleHidden() {
         frame.window.move(frame.x_hidden, frame.y_hidden);
     else {
         frame.window.move(frame.x, frame.y);
-        forAll(m_item_list, std::mem_fun(&ToolbarItem::parentMoved));
+        forAll(m_item_list, std::mem_fn(&ToolbarItem::parentMoved));
     }
 
 }

--- a/src/WinClient.cc
+++ b/src/WinClient.cc
@@ -52,7 +52,7 @@
 
 using std::string;
 using std::list;
-using std::mem_fun;
+using std::mem_fn;
 using std::endl;
 using std::cerr;
 using std::hex;
@@ -115,7 +115,7 @@ WinClient::WinClient(Window win, BScreen &screen, FluxboxWindow *fbwin):
         // For each transient that waits call updateTransientInfo
         for_each(s_transient_wait[win].begin(),
                  s_transient_wait[win].end(),
-                 mem_fun(&WinClient::updateTransientInfo));
+                 mem_fn(&WinClient::updateTransientInfo));
         // clear transient waiting list for this window
         s_transient_wait.erase(win);
     }

--- a/src/Window.cc
+++ b/src/Window.cc
@@ -73,14 +73,14 @@
 using std::endl;
 using std::string;
 using std::vector;
-using std::bind2nd;
-using std::mem_fun;
+using std::mem_fn;
 using std::equal_to;
 using std::max;
 using std::swap;
 using std::dec;
 using std::hex;
 
+using namespace std::placeholders;
 using namespace FbTk;
 
 namespace {
@@ -815,8 +815,8 @@ bool FluxboxWindow::removeClient(WinClient &client) {
 WinClient *FluxboxWindow::findClient(Window win) {
     ClientList::iterator it = find_if(clientList().begin(),
                                       clientList().end(),
-                                      Compose(bind2nd(equal_to<Window>(), win),
-                                              mem_fun(&WinClient::window)));
+                                      Compose(std::bind(equal_to<Window>(), _1, win),
+                                              mem_fn(&WinClient::window)));
     return (it == clientList().end() ? 0 : *it);
 }
 
@@ -3379,8 +3379,8 @@ WinClient* FluxboxWindow::winClientOfLabelButtonWindow(Window window) {
     Client2ButtonMap::iterator it =
         find_if(m_labelbuttons.begin(),
                 m_labelbuttons.end(),
-                Compose(bind2nd(equal_to<Window>(), window),
-                        Compose(mem_fun(&FbTk::Button::window),
+                Compose(std::bind(equal_to<Window>(), _1, window),
+                        Compose(mem_fn(&FbTk::Button::window),
                                 Select2nd<Client2ButtonMap::value_type>())));
     if (it != m_labelbuttons.end())
         result = it->first;

--- a/src/WorkspaceCmd.cc
+++ b/src/WorkspaceCmd.cc
@@ -720,12 +720,12 @@ void CloseAllWindowsCmd::execute() {
     for (; workspace_it != workspace_it_end; ++workspace_it) {
         windows = (*workspace_it)->windowList();
         std::for_each(windows.begin(), windows.end(),
-                std::mem_fun(&FluxboxWindow::close));
+                std::mem_fn(&FluxboxWindow::close));
     }
 
     windows = screen->iconList();
     std::for_each(windows.begin(),
-            windows.end(), std::mem_fun(&FluxboxWindow::close));
+            windows.end(), std::mem_fn(&FluxboxWindow::close));
 
 }
 

--- a/src/fluxbox.cc
+++ b/src/fluxbox.cc
@@ -119,12 +119,12 @@ using std::string;
 using std::vector;
 using std::list;
 using std::pair;
-using std::bind2nd;
-using std::mem_fun;
+using std::mem_fn;
 using std::equal_to;
 using std::hex;
 using std::dec;
 
+using namespace std::placeholders;
 using namespace FbTk;
 
 namespace {
@@ -212,7 +212,7 @@ typedef FbTk::SimpleCommand<Fluxbox> FluxboxCmd;
    a newer compiler.
  */
 template <typename Type, typename ArgType, typename ResultType>
-struct CallMemFunWithRefArg : std::unary_function<Type, ResultType> {
+struct CallMemFunWithRefArg {
 
     explicit CallMemFunWithRefArg(ResultType (Type::*func)(ArgType), ArgType arg) :
         m_arg(arg),
@@ -446,7 +446,7 @@ Fluxbox::Fluxbox(int argc, char **argv,
 #endif // REMEMBER
 
     // init all "screens"
-    STLUtil::forAll(m_screens, bind1st(mem_fun(&Fluxbox::initScreen), this));
+    STLUtil::forAll(m_screens, std::bind(mem_fn(&Fluxbox::initScreen), this, _1));
 
     XAllowEvents(disp, ReplayPointer, CurrentTime);
 
@@ -514,7 +514,7 @@ void Fluxbox::initScreen(BScreen *screen) {
     // initiate atomhandler for screen specific stuff
     STLUtil::forAll(m_atomhandler, 
             CallMemFunWithRefArg<AtomHandler, BScreen&, void>(&AtomHandler::initForScreen, *screen));
-    //STLUtil::forAll(m_atomhandler, bind2nd(mem_fun(&AtomHandler::initForScreen), *screen));
+    //STLUtil::forAll(m_atomhandler, bind2nd(mem_fn(&AtomHandler::initForScreen), *screen));
 
     FocusControl::revertFocus(*screen); // make sure focus style is correct
 
@@ -898,7 +898,7 @@ void Fluxbox::handleClientMessage(XClientMessageEvent &ce) {
 void Fluxbox::windowDied(Focusable &focusable) {
     FluxboxWindow *fbwin = focusable.fbwindow();
 
-    STLUtil::forAllIf(m_atomhandler, mem_fun(&AtomHandler::update),
+    STLUtil::forAllIf(m_atomhandler, mem_fn(&AtomHandler::update),
         CallMemFunWithRefArg<AtomHandler, FluxboxWindow&, void>(&AtomHandler::updateFrameClose, *focusable.fbwindow()));
 
     // make sure each workspace get this
@@ -911,7 +911,7 @@ void Fluxbox::windowDied(Focusable &focusable) {
 void Fluxbox::clientDied(Focusable &focusable) {
     WinClient &client = dynamic_cast<WinClient &>(focusable);
 
-    STLUtil::forAllIf(m_atomhandler, mem_fun(&AtomHandler::update),
+    STLUtil::forAllIf(m_atomhandler, mem_fn(&AtomHandler::update),
             CallMemFunWithRefArg<AtomHandler, WinClient&, void>(&AtomHandler::updateClientClose, client));
 
     BScreen &screen = client.screen();
@@ -935,12 +935,12 @@ void Fluxbox::clientDied(Focusable &focusable) {
 }
 
 void Fluxbox::windowWorkspaceChanged(FluxboxWindow &win) {
-    STLUtil::forAllIf(m_atomhandler, mem_fun(&AtomHandler::update),
+    STLUtil::forAllIf(m_atomhandler, mem_fn(&AtomHandler::update),
         CallMemFunWithRefArg<AtomHandler, FluxboxWindow&, void>(&AtomHandler::updateWorkspace, win));
 }
 
 void Fluxbox::windowStateChanged(FluxboxWindow &win) {
-    STLUtil::forAllIf(m_atomhandler, mem_fun(&AtomHandler::update),
+    STLUtil::forAllIf(m_atomhandler, mem_fn(&AtomHandler::update),
         CallMemFunWithRefArg<AtomHandler, FluxboxWindow&, void>(&AtomHandler::updateState, win));
 
     // if window changed to iconic state
@@ -962,7 +962,7 @@ void Fluxbox::windowStateChanged(FluxboxWindow &win) {
 }
 
 void Fluxbox::windowLayerChanged(FluxboxWindow &win) {
-    STLUtil::forAllIf(m_atomhandler, mem_fun(&AtomHandler::update),
+    STLUtil::forAllIf(m_atomhandler, mem_fn(&AtomHandler::update),
         CallMemFunWithRefArg<AtomHandler, FluxboxWindow&, void>(&AtomHandler::updateLayer, win));
 }
 
@@ -1103,7 +1103,7 @@ void Fluxbox::shutdown(int x_wants_down) {
     XSetInputFocus(dpy, PointerRoot, None, CurrentTime);
 
     if (x_wants_down == 0) {
-        STLUtil::forAll(m_screens, mem_fun(&BScreen::shutdown));
+        STLUtil::forAll(m_screens, mem_fn(&BScreen::shutdown));
         sync(false);
     }
 }
@@ -1305,9 +1305,9 @@ void Fluxbox::real_reconfigure() {
     for (; screen_it != screen_it_end; ++screen_it)
         load_rc(*(*screen_it));
 
-    STLUtil::forAll(m_screens, mem_fun(&BScreen::reconfigure));
+    STLUtil::forAll(m_screens, mem_fn(&BScreen::reconfigure));
     m_key->reconfigure();
-    STLUtil::forAll(m_atomhandler, mem_fun(&AtomHandler::reconfigure));
+    STLUtil::forAll(m_atomhandler, mem_fn(&AtomHandler::reconfigure));
     FbTk::MenuSearch::setMode(*m_config.menusearch);
 }
 
@@ -1362,7 +1362,7 @@ bool Fluxbox::validateClient(const WinClient *client) const {
     WinClientMap::const_iterator it =
         find_if(m_window_search.begin(),
                 m_window_search.end(),
-                Compose(bind2nd(equal_to<const WinClient *>(), client),
+                Compose(std::bind(equal_to<const WinClient *>(), _1, client),
                         Select2nd<WinClientMap::value_type>()));
     return it != m_window_search.end();
 }
@@ -1373,22 +1373,22 @@ void Fluxbox::updateFrameExtents(FluxboxWindow &win) {
 }
 
 void Fluxbox::workspaceCountChanged( BScreen& screen ) {
-    STLUtil::forAllIf(m_atomhandler, mem_fun(&AtomHandler::update),
+    STLUtil::forAllIf(m_atomhandler, mem_fn(&AtomHandler::update),
             CallMemFunWithRefArg<AtomHandler, BScreen&, void>(&AtomHandler::updateWorkspaceCount, screen));
 }
 
 void Fluxbox::workspaceChanged( BScreen& screen ) {
-    STLUtil::forAllIf(m_atomhandler, mem_fun(&AtomHandler::update),
+    STLUtil::forAllIf(m_atomhandler, mem_fn(&AtomHandler::update),
             CallMemFunWithRefArg<AtomHandler, BScreen&, void>(&AtomHandler::updateCurrentWorkspace, screen));
 }
 
 void Fluxbox::workspaceNamesChanged(BScreen &screen) {
-    STLUtil::forAllIf(m_atomhandler, mem_fun(&AtomHandler::update),
+    STLUtil::forAllIf(m_atomhandler, mem_fn(&AtomHandler::update),
             CallMemFunWithRefArg<AtomHandler, BScreen&, void>(&AtomHandler::updateWorkspaceNames, screen));
 }
 
 void Fluxbox::clientListChanged(BScreen &screen) {
-    STLUtil::forAllIf(m_atomhandler, mem_fun(&AtomHandler::update),
+    STLUtil::forAllIf(m_atomhandler, mem_fn(&AtomHandler::update),
             CallMemFunWithRefArg<AtomHandler, BScreen&, void>(&AtomHandler::updateClientList, screen));
 }
 
@@ -1403,7 +1403,7 @@ void Fluxbox::focusedWindowChanged(BScreen &screen,
 }
 
 void Fluxbox::workspaceAreaChanged(BScreen &screen) {
-    STLUtil::forAllIf(m_atomhandler, mem_fun(&AtomHandler::update),
+    STLUtil::forAllIf(m_atomhandler, mem_fn(&AtomHandler::update),
             CallMemFunWithRefArg<AtomHandler, BScreen&, void>(&AtomHandler::updateWorkarea, screen));
 }
 

--- a/util/fbsetroot.cc
+++ b/util/fbsetroot.cc
@@ -219,7 +219,7 @@ void fbsetroot::modula(int x, int y) {
     char data[32];
     long pattern = 0;
 
-    register int i;
+    int i;
 
     FbRootWindow root(screen);
 


### PR DESCRIPTION
  Most warnings were caused by deprecated std library templates,
  especially std::mem_fun, std::bind1st, and std::bind2nd. These
  are replaced by their modern versions, std::mem_fn and std::bind.

Note: I have just gotten a new computer and so am in the process of re-compiling and installing fluxbox. This provided the opportunity for me to look at and attempt to update/improve my several pull requests of the past. I see that the oldest (and perhaps most important one) #58 failed to be merged because I folded warning removal into the PR (as I worried about at the time I filed it, as you can see in the discussion there). So in my effort to update/revive #58, I felt it would be best first to remove the warnings in a stand-alone PR. That's what this is. Hopefully this can be merged. Once it is, I can file a new PR superseding #58 to respect _NET_WM_VISIBLE_NAME on top of a warning-free base. (My apologies, but working on the EWMH code with the templates in the signal system in the presence of many other warnings just exceeded my capacity.)

Oddly enough, in the intervening time, or perhaps just because there may be a somewhat different environment on the new computer even though it is still openSUSE Tumbleweed, there were no warnings at all about signed/unsigned mismatches, even though clearly a year or so ago I was encountering many. Hopefully that will also make this PR easier/quicker to merge, as I believe it has significantly fewer changes than the (warning parts of) #58.

Looking forward hopefully to getting through this and getting some of the features/fixes merged into fluxbox. Thanks!