### PR TITLE
add "(on $CLIENT)" to forwarded client titlebars

### DIFF
--- a/src/WinClient.hh
+++ b/src/WinClient.hh
@@ -91,6 +91,7 @@ public:
     //
 
     bool getAttrib(XWindowAttributes &attr) const;
+    bool getWMClientMachine(XTextProperty &textprop) const;
     bool getWMName(XTextProperty &textprop) const;
     bool getWMIconName(XTextProperty &textprop) const;
     std::string getWMRole() const;

--- a/src/Xutil.cc
+++ b/src/Xutil.cc
@@ -43,6 +43,51 @@ using std::endl;
 
 namespace Xutil {
 
+FbTk::FbString getWMClientMachine(Window window) {
+
+    if (window == None)
+        return FbTk::FbString("");
+
+    Display *display = FbTk::App::instance()->display();
+
+    XTextProperty text_prop;
+    text_prop.value = 0;
+    char **list = 0;
+    int num = 0;
+    _FB_USES_NLS;
+    FbTk::FbString name;
+
+    if (XGetWMClientMachine(display, window, &text_prop)) {
+        if (text_prop.value && text_prop.nitems > 0) {
+            if (text_prop.encoding != XA_STRING) {
+
+                text_prop.nitems = strlen((char *) text_prop.value);
+                XmbTextPropertyToTextList(display, &text_prop, &list, &num);
+
+                if (num > 0 && list != 0)
+                    name = FbTk::FbStringUtil::LocaleStrToFb(static_cast<char *>(*list));
+                else
+                    name = text_prop.value ? FbTk::FbStringUtil::XStrToFb((char *)text_prop.value) : "";
+
+                if (list)
+                    XFreeStringList(list);
+
+            } else
+                name = text_prop.value ? FbTk::FbStringUtil::XStrToFb((char *)text_prop.value) : "";
+
+            XFree(text_prop.value);
+
+        } else { // default name
+            name = _FB_XTEXT(Window, Unnamed, "Unnamed", "Default name for a window without a WM_NAME");
+        }
+    } else {
+        // default name
+        name = _FB_XTEXT(Window, Unnamed, "Unnamed", "Default name for a window without a WM_NAME");
+    }
+
+    return name;
+}
+
 FbTk::FbString getWMName(Window window) {
 
     if (window == None)

--- a/src/Xutil.hh
+++ b/src/Xutil.hh
@@ -28,6 +28,7 @@
 
 namespace Xutil {
 
+FbTk::FbString getWMClientMachine(Window window);
 FbTk::FbString getWMName(Window window);
 
 FbTk::FbString getWMClassName(Window win);


### PR DESCRIPTION
This could be improved by storing gethostname() response on something like the display object (the way Xfwm4 does it). Also, adding a configurable option for the init file would be great but I didn't poke at that yet.