### PR TITLE
util/fbsetroot: Don't use register keyword

### DIFF
--- a/util/fbsetroot.cc
+++ b/util/fbsetroot.cc
@@ -219,7 +219,7 @@ void fbsetroot::modula(int x, int y) {
     char data[32];
     long pattern = 0;
 
-    register int i;
+    int i;
 
     FbRootWindow root(screen);
 


### PR DESCRIPTION
Register keyword has been deprecated since c++14 and completely removed since c++17.

Encountered while building fluxbox with clang-16.