### PR TITLE
Set WithdrawnState state when handling unmap notify events.

### DIFF
--- a/src/Window.cc
+++ b/src/Window.cc
@@ -2159,6 +2159,7 @@ void FluxboxWindow::unmapNotifyEvent(XUnmapEvent &ue) {
 
     if (numClients() == 1) // unmapping the last client
         frame().hide(); // hide this now, otherwise compositors will fade out the frame, bug #1110
+    setState(WithdrawnState, false);
     restore(client, false);
 
 }


### PR DESCRIPTION
Wine calls XWithdrawWindow() and waits for window managers to change the window state to withdrawn and send to property notify event. If the state is not changed by the WM, then Wine windows may stuck in withdrawn state and never get mapped. Although there is no standard that window managers must honor the request, it seems right to fix this on the fluxbox side.

Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=58195
Wine-Bug: https://bugs.winehq.org/show_bug.cgi?id=58223