### PR TITLE
Fix RandR notify event detection to also handle RRNotify type events

### DIFF
--- a/src/fluxbox.cc
+++ b/src/fluxbox.cc
@@ -800,7 +800,12 @@ void Fluxbox::handleEvent(XEvent * const e) {
     default: {
 
 #if defined(HAVE_RANDR) || defined(HAVE_RANDR1_2)
-        if (e->type == s_randr_event_type) {
+        bool is_randr_event = (e->type == s_randr_event_type);
+#ifdef RRNotify
+        is_randr_event = is_randr_event ||
+                         (e->type == s_randr_event_type + RRNotify);
+#endif
+        if (is_randr_event) {
 #ifdef HAVE_RANDR1_2
             XRRUpdateConfiguration(e);
 #endif


### PR DESCRIPTION
Right now the Fluxbox code here is only intended to detect screen size changes from RandR. The `e->type == s_randr_event_type` is not the event type sent when the monitor is power-cycled. For many years now, anytime I turned off my monitor and turned it back on, Fluxbox would be in a broken state until I restarted it. (Specifically, after a monitor power cycle, newly created windows would not have any decoration and would be placed in the top left of the screen. Trying to move the windows would draw like they were being moved but wouldn't actually move them. Restarting Fluxbox would re-add the decorations to them and move them wherever they were supposed to be.)

By also handling the RRNotify event type and calling `scr->updateSize();` (which in turn calls `initXinerama()`) Fluxbox seems to properly handle the monitor going away and then coming back.

I've been a Fluxbox user continuously since 2004 and this is the only issue I've ever run into. I'm glad to have it finally fixed.